### PR TITLE
feat(crawler): add ENR storage and retrieval to Crawler

### DIFF
--- a/pkg/consensus/mimicry/crawler/crawler_test.go
+++ b/pkg/consensus/mimicry/crawler/crawler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethpandaops/beacon/pkg/beacon"
 	"github.com/ethpandaops/beacon/pkg/beacon/api/types"
 	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/crawler"
@@ -197,7 +198,7 @@ func setupCrawler(t *testing.T, tf *kurtosis.TestFoundation, network network.Net
 func setupCrawlerEventHandlers(t *testing.T, cr *crawler.Crawler, logger *logrus.Logger, identities map[string]*types.Identity, successful map[string]bool, mu *sync.Mutex) {
 	t.Helper()
 
-	cr.OnSuccessfulCrawl(func(peerID peer.ID, status *common.Status, metadata *common.MetaData) {
+	cr.OnSuccessfulCrawl(func(peerID peer.ID, enr *enode.Node, status *common.Status, metadata *common.MetaData) {
 		logger.Infof("Got status/metadata: %s", peerID)
 
 		// Get the service name

--- a/pkg/consensus/mimicry/crawler/enr_simple_test.go
+++ b/pkg/consensus/mimicry/crawler/enr_simple_test.go
@@ -1,0 +1,123 @@
+package crawler
+
+import (
+	"net"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethpandaops/ethcore/pkg/discovery"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrawler_GetPeerENR(t *testing.T) {
+	// Create a simple crawler instance with just the ENR storage initialized
+	c := &Crawler{
+		peerENRs: make(map[peer.ID]*enode.Node),
+	}
+
+	// Create a test ENR
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	record := &enr.Record{}
+	record.Set(enr.IP(net.ParseIP("192.168.1.1")))
+	record.Set(enr.TCP(30303))
+	require.NoError(t, enode.SignV4(record, privKey))
+
+	node, err := enode.New(enode.ValidSchemes, record)
+	require.NoError(t, err)
+
+	// Derive peer info
+	connectablePeer, err := discovery.DeriveDetailsFromNode(node)
+	require.NoError(t, err)
+
+	peerID := connectablePeer.AddrInfo.ID
+
+	// Test 1: ENR should be nil for unknown peer
+	assert.Nil(t, c.GetPeerENR(peerID))
+
+	// Test 2: Store ENR
+	c.peerENRsMu.Lock()
+	c.peerENRs[peerID] = node
+	c.peerENRsMu.Unlock()
+
+	// Test 3: Retrieved ENR should match stored ENR
+	retrievedENR := c.GetPeerENR(peerID)
+	assert.NotNil(t, retrievedENR)
+	assert.Equal(t, node.ID().String(), retrievedENR.ID().String())
+
+	// Test 4: Delete ENR
+	c.peerENRsMu.Lock()
+	delete(c.peerENRs, peerID)
+	c.peerENRsMu.Unlock()
+
+	// Test 5: ENR should be nil after deletion
+	assert.Nil(t, c.GetPeerENR(peerID))
+}
+
+func TestCrawler_ENRConcurrency(t *testing.T) {
+	// Test concurrent access to ENR storage
+	c := &Crawler{
+		peerENRs: make(map[peer.ID]*enode.Node),
+	}
+
+	// Create multiple test ENRs
+	numPeers := 10
+	peers := make([]peer.ID, numPeers)
+	nodes := make([]*enode.Node, numPeers)
+
+	for i := 0; i < numPeers; i++ {
+		privKey, err := crypto.GenerateKey()
+		require.NoError(t, err)
+
+		record := &enr.Record{}
+		record.Set(enr.IP(net.ParseIP("192.168.1.1")))
+		record.Set(enr.TCP(uint16(30303 + i)))
+		require.NoError(t, enode.SignV4(record, privKey))
+
+		node, err := enode.New(enode.ValidSchemes, record)
+		require.NoError(t, err)
+
+		connectablePeer, err := discovery.DeriveDetailsFromNode(node)
+		require.NoError(t, err)
+
+		peers[i] = connectablePeer.AddrInfo.ID
+		nodes[i] = node
+	}
+
+	// Concurrently store and retrieve ENRs
+	done := make(chan struct{})
+
+	// Writer goroutine
+	go func() {
+		for i := 0; i < numPeers; i++ {
+			c.peerENRsMu.Lock()
+			c.peerENRs[peers[i]] = nodes[i]
+			c.peerENRsMu.Unlock()
+		}
+		close(done)
+	}()
+
+	// Reader goroutine
+	go func() {
+		for i := 0; i < 100; i++ {
+			for j := 0; j < numPeers; j++ {
+				_ = c.GetPeerENR(peers[j])
+			}
+		}
+	}()
+
+	// Wait for writer to complete
+	<-done
+
+	// Verify all ENRs were stored correctly
+	for i := 0; i < numPeers; i++ {
+		enr := c.GetPeerENR(peers[i])
+		assert.NotNil(t, enr)
+		assert.Equal(t, nodes[i].ID().String(), enr.ID().String())
+	}
+}

--- a/pkg/consensus/mimicry/crawler/event.go
+++ b/pkg/consensus/mimicry/crawler/event.go
@@ -2,9 +2,8 @@ package crawler
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/jellydator/ttlcache/v3"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
 )
@@ -23,7 +22,7 @@ var (
 
 type OnPeerStatusUpdatedCallback func(peerID peer.ID, status *common.Status)
 type OnMetadataReceivedCallback func(peerID peer.ID, metadata *common.MetaData)
-type OnSuccessfulCrawlCallback func(peerID peer.ID, status *common.Status, metadata *common.MetaData)
+type OnSuccessfulCrawlCallback func(peerID peer.ID, enr *enode.Node, status *common.Status, metadata *common.MetaData)
 type OnFailedCrawlCallback func(peerID peer.ID, err CrawlError)
 
 // OnPeerStatusUpdated subscribes to the peer status updated event.
@@ -55,9 +54,7 @@ func (n *Crawler) emitMetadataReceived(peerID peer.ID, metadata *common.MetaData
 }
 
 func (n *Crawler) emitSuccessfulCrawl(peerID peer.ID, status *common.Status, metadata *common.MetaData) {
-	// Add the peer to the duplicate cache to prevent re-crawling too soon
-	n.duplicateCache.GetCache().Set(peerID.String(), time.Now(), ttlcache.DefaultTTL)
-	n.broker.Emit(OnSuccessfulCrawl, peerID, status, metadata)
+	n.broker.Emit(OnSuccessfulCrawl, peerID, n.GetPeerENR(peerID), status, metadata)
 }
 
 func (n *Crawler) emitFailedCrawl(peerID peer.ID, err CrawlError) {

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -78,7 +78,7 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 		c.metrics.RecordFailedCrawl(reason.Error())
 	})
 
-	c.OnSuccessfulCrawl(func(peerID peer.ID, status *common.Status, metadata *common.MetaData) {
+	c.OnSuccessfulCrawl(func(peerID peer.ID, enr *enode.Node, status *common.Status, metadata *common.MetaData) {
 		c.metrics.RecordSuccessfulCrawl(string(clients.ClientFromString(c.GetPeerAgentVersion(peerID))))
 	})
 
@@ -309,7 +309,7 @@ func (c *Crawler) startDialer(ctx context.Context) error {
 				c.metrics.RecordNodeProcessed()
 				c.metrics.RecordPendingDials(len(c.peersToDial))
 
-				if err := c.node.ConnectToPeer(ctx, node.AddrInfo); err != nil {
+				if err := c.ConnectToPeer(ctx, node.AddrInfo, node.Enode); err != nil {
 					c.log.WithError(err).Trace("Failed to connect to peer")
 				}
 			}


### PR DESCRIPTION
The Crawler now stores and retrieves Ethereum Node Records (ENRs) for connected peers. It also publishes the ENR on successful crawl. This is handy for consumers (eg: xatu/discovery).
