### PR TITLE
refactor(crawler): improve graceful shutdown and context handling

### DIFF
--- a/pkg/consensus/mimicry/crawler/error.go
+++ b/pkg/consensus/mimicry/crawler/error.go
@@ -23,6 +23,8 @@ var (
 	ErrCrawlStatusForkDigest = CrawlError{Msg: "wrong fork digest in status message", Type: "wrong_status_fork_digest"}
 	// ErrCrawlFailedToRequestStatus indicates that we failed to request status from the peer.
 	ErrCrawlFailedToRequestStatus = CrawlError{Msg: "failed to request status", Type: "failed_request_status"}
+	// ErrCrawlFailedToRequestMetadata indicates that we failed to request metadata from the peer.
+	ErrCrawlFailedToRequestMetadata = CrawlError{Msg: "failed to request metadata", Type: "failed_request_metadata"}
 	// ErrCrawlIdentifyTimeout indicates that the libp2p identify protocol timed out.
 	ErrCrawlIdentifyTimeout = CrawlError{Msg: "identify protocol timeout", Type: "identify_timeout"}
 )

--- a/pkg/consensus/mimicry/host/host.go
+++ b/pkg/consensus/mimicry/host/host.go
@@ -132,11 +132,19 @@ func (n *Node) Start(ctx context.Context) (host.Host, error) {
 }
 
 func (n *Node) Stop(ctx context.Context) error {
-	return n.host.Close()
+	if n.host != nil {
+		return n.host.Close()
+	}
+
+	return nil
 }
 
 func (n *Node) Peerstore() peerstore.Peerstore {
-	return n.host.Peerstore()
+	if n.host != nil {
+		return n.host.Peerstore()
+	}
+
+	return nil
 }
 
 func (n *Node) Network() network.Network {


### PR DESCRIPTION
Nothing in the crawler was respecting shutdown/sigterm/ctx-cancellation.