### PR TITLE
refactor(cache): adds Prometheus metrics to generic duplicate cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/kurtosis-tech/kurtosis/grpc-file-transfer/golang v0.0.0-20230803130419-099ee7a4e3dc // indirect
 	github.com/kurtosis-tech/kurtosis/path-compression v0.0.0-20240307154559-64d2929cd265 // indirect
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.4.1 // indirect

--- a/pkg/cache/README.md
+++ b/pkg/cache/README.md
@@ -1,0 +1,74 @@
+# Cache Package
+
+This package provides a generic duplicate cache with optional Prometheus metrics support.
+
+## Features
+
+- Generic type-safe cache implementation
+- TTL-based expiration
+- Optional capacity limits
+- Prometheus metrics integration (opt-in)
+- Scheduled metrics updates
+- Thread-safe operations
+
+## Usage
+
+### Basic Usage (without metrics)
+
+```go
+import (
+    "time"
+    "github.com/sirupsen/logrus"
+    "github.com/ethpandaops/ethcore/pkg/cache"
+)
+
+// Create a simple cache
+log := logrus.New()
+ttl := 5 * time.Minute
+cache := cache.NewDuplicateCache[string, string](log, ttl)
+
+// Start the cache
+ctx := context.Background()
+cache.Start(ctx)
+defer cache.Stop()
+
+// Use the cache
+cache.Set("key1", "value1")
+if cache.Has("key1") {
+    item := cache.Get("key1")
+    fmt.Println(item.Value()) // "value1"
+}
+```
+
+### Advanced Usage (with metrics)
+
+```go
+config := cache.Config{
+    TTL:      120 * time.Minute,
+    Capacity: 10000, // Optional capacity limit
+    Metrics: &cache.MetricsConfig{
+        Namespace: "myapp",
+        Subsystem: "cache",
+        InstanceLabels: map[string]string{
+            "cache_type": "session",
+            "region":     "us-east",
+        },
+        UpdateInterval: 10 * time.Second,
+        Registerer:     prometheus.DefaultRegisterer,
+    },
+}
+
+cache := cache.NewDuplicateCacheWithConfig[string, time.Time](log, config)
+```
+
+## Metrics
+
+When metrics are enabled, the following Prometheus metrics are exposed:
+
+- `{namespace}_{subsystem}_insertions_total` - Total number of cache insertions
+- `{namespace}_{subsystem}_hits_total` - Total number of cache hits
+- `{namespace}_{subsystem}_misses_total` - Total number of cache misses
+- `{namespace}_{subsystem}_evictions_total` - Total number of cache evictions
+- `{namespace}_{subsystem}_size` - Current number of items in the cache
+
+All metrics include the labels specified in `InstanceLabels`.

--- a/pkg/cache/duplicate.go
+++ b/pkg/cache/duplicate.go
@@ -2,8 +2,10 @@ package cache
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
+	"github.com/go-co-op/gocron/v2"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -14,6 +16,12 @@ type DuplicateCache[K comparable, V any] interface {
 	Start(ctx context.Context) error
 	// Stop gracefully shuts down the cache and its background operations.
 	Stop() error
+	// Set adds an item to the cache with metrics tracking.
+	Set(key K, value V, ttl ...time.Duration) *ttlcache.Item[K, V]
+	// Get retrieves an item from the cache with metrics tracking.
+	Get(key K) *ttlcache.Item[K, V]
+	// Has checks if a key exists in the cache with metrics tracking.
+	Has(key K) bool
 	// GetCache returns the underlying TTL cache.
 	GetCache() *ttlcache.Cache[K, V]
 }
@@ -27,6 +35,8 @@ type Config struct {
 	Capacity uint64
 	// OnEviction is called when an item is evicted from the cache.
 	OnEviction func(key any, value any, reason ttlcache.EvictionReason)
+	// Metrics configuration. If nil, metrics are disabled.
+	Metrics *MetricsConfig
 }
 
 // DefaultConfig returns a Config with default values.
@@ -39,8 +49,19 @@ func DefaultConfig() Config {
 
 // duplicateCache implements the DuplicateCache interface.
 type duplicateCache[K comparable, V any] struct {
-	cache *ttlcache.Cache[K, V]
-	log   logrus.FieldLogger
+	cache  *ttlcache.Cache[K, V]
+	log    logrus.FieldLogger
+	config Config
+
+	// Metrics
+	metrics       *Metrics
+	metricsLabels []string // Cached label values in correct order
+
+	// Scheduler for metrics updates
+	scheduler gocron.Scheduler
+
+	// Atomic counters for metrics that aren't exposed by ttlcache
+	insertions atomic.Uint64
 
 	cancel context.CancelFunc
 }
@@ -57,16 +78,37 @@ func NewDuplicateCacheWithConfig[K comparable, V any](log logrus.FieldLogger, co
 
 	cache := ttlcache.New(opts...)
 
-	if config.OnEviction != nil {
+	d := &duplicateCache[K, V]{
+		cache:  cache,
+		log:    log.WithField("module", "ethcore/cache"),
+		config: config,
+	}
+
+	// Set up eviction callback
+	if config.OnEviction != nil || config.Metrics != nil {
 		cache.OnEviction(func(ctx context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[K, V]) {
-			config.OnEviction(item.Key(), item.Value(), reason)
+			if config.OnEviction != nil {
+				config.OnEviction(item.Key(), item.Value(), reason)
+			}
+
+			if d.metrics != nil {
+				d.metrics.IncEvictions(d.metricsLabels...)
+			}
 		})
 	}
 
-	return &duplicateCache[K, V]{
-		cache: cache,
-		log:   log.WithField("module", "ethcore/cache"),
+	// Initialize metrics if configured
+	if config.Metrics != nil {
+		d.metrics = NewMetrics(*config.Metrics)
+		if err := d.metrics.Register(config.Metrics.Registerer); err != nil {
+			log.WithError(err).Warn("Failed to register cache metrics")
+		}
+
+		// Cache the label values for efficient metric updates
+		d.metricsLabels = d.metrics.ExtractLabelValues(config.Metrics.InstanceLabels)
 	}
+
+	return d
 }
 
 // NewDuplicateCache creates a new DuplicateCache with just a TTL duration.
@@ -80,11 +122,18 @@ func NewDuplicateCache[K comparable, V any](log logrus.FieldLogger, ttl time.Dur
 
 // Start initializes the cache and begins background cleanup operations.
 func (d *duplicateCache[K, V]) Start(ctx context.Context) error {
-	_, d.cancel = context.WithCancel(ctx)
+	ctx, d.cancel = context.WithCancel(ctx)
 
 	go func() {
 		d.cache.Start()
 	}()
+
+	// Start metrics scheduler if metrics are enabled
+	if d.metrics != nil {
+		if err := d.startMetricsScheduler(ctx); err != nil {
+			return err
+		}
+	}
 
 	d.log.Info("Duplicate cache started")
 
@@ -99,14 +148,129 @@ func (d *duplicateCache[K, V]) Stop() error {
 		d.cancel()
 	}
 
+	// Stop metrics scheduler
+	if d.scheduler != nil {
+		if err := d.scheduler.Shutdown(); err != nil {
+			d.log.WithError(err).Warn("Failed to shutdown metrics scheduler")
+		}
+	}
+
 	d.cache.Stop()
+
+	// Unregister metrics
+	if d.metrics != nil && d.config.Metrics != nil {
+		d.metrics.Unregister(d.config.Metrics.Registerer)
+	}
 
 	d.log.Info("Duplicate cache stopped")
 
 	return nil
 }
 
+// Set adds an item to the cache with metrics tracking.
+func (d *duplicateCache[K, V]) Set(key K, value V, ttl ...time.Duration) *ttlcache.Item[K, V] {
+	var item *ttlcache.Item[K, V]
+
+	if len(ttl) > 0 {
+		item = d.cache.Set(key, value, ttl[0])
+	} else {
+		item = d.cache.Set(key, value, ttlcache.DefaultTTL)
+	}
+
+	if d.metrics != nil {
+		d.insertions.Add(1)
+		d.metrics.IncInsertions(d.metricsLabels...)
+	}
+
+	return item
+}
+
+// Get retrieves an item from the cache with metrics tracking.
+func (d *duplicateCache[K, V]) Get(key K) *ttlcache.Item[K, V] {
+	item := d.cache.Get(key)
+
+	if d.metrics != nil {
+		if item != nil {
+			d.metrics.IncHits(d.metricsLabels...)
+		} else {
+			d.metrics.IncMisses(d.metricsLabels...)
+		}
+	}
+
+	return item
+}
+
+// Has checks if a key exists in the cache with metrics tracking.
+func (d *duplicateCache[K, V]) Has(key K) bool {
+	has := d.cache.Has(key)
+
+	if d.metrics != nil {
+		if has {
+			d.metrics.IncHits(d.metricsLabels...)
+		} else {
+			d.metrics.IncMisses(d.metricsLabels...)
+		}
+	}
+
+	return has
+}
+
 // GetCache returns the underlying TTL cache.
 func (d *duplicateCache[K, V]) GetCache() *ttlcache.Cache[K, V] {
 	return d.cache
+}
+
+// startMetricsScheduler starts the scheduler for periodic metrics updates.
+func (d *duplicateCache[K, V]) startMetricsScheduler(ctx context.Context) error {
+	scheduler, err := gocron.NewScheduler(gocron.WithLocation(time.Local))
+	if err != nil {
+		return err
+	}
+
+	d.scheduler = scheduler
+
+	// Determine update interval
+	interval := d.config.Metrics.UpdateInterval
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+
+	// Schedule periodic metrics updates
+	if _, err := d.scheduler.NewJob(
+		gocron.DurationJob(interval),
+		gocron.NewTask(
+			func(ctx context.Context) {
+				d.updateMetrics()
+			},
+			ctx,
+		),
+		gocron.WithStartAt(gocron.WithStartImmediately()),
+	); err != nil {
+		return err
+	}
+
+	d.scheduler.Start()
+
+	return nil
+}
+
+// updateMetrics updates the metrics with current cache statistics.
+func (d *duplicateCache[K, V]) updateMetrics() {
+	if d.metrics == nil {
+		return
+	}
+
+	// Update size metric
+	d.metrics.SetSize(float64(d.cache.Len()), d.metricsLabels...)
+
+	// Log metrics for debugging
+	metrics := d.cache.Metrics()
+
+	d.log.WithFields(logrus.Fields{
+		"insertions": d.insertions.Load(),
+		"hits":       metrics.Hits,
+		"misses":     metrics.Misses,
+		"evictions":  metrics.Evictions,
+		"size":       d.cache.Len(),
+	}).Debug("Cache metrics updated")
 }

--- a/pkg/cache/metrics.go
+++ b/pkg/cache/metrics.go
@@ -1,0 +1,198 @@
+package cache
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics holds Prometheus metrics for cache operations.
+type Metrics struct {
+	namespace string
+	subsystem string
+	labels    []string
+
+	// Metrics
+	insertionsTotal *prometheus.CounterVec
+	hitsTotal       *prometheus.CounterVec
+	missesTotal     *prometheus.CounterVec
+	evictionsTotal  *prometheus.CounterVec
+	sizeGauge       *prometheus.GaugeVec
+
+	// Registration tracking
+	registered bool
+	mu         sync.Mutex
+}
+
+// MetricsConfig holds configuration for cache metrics.
+type MetricsConfig struct {
+	// Namespace is the prometheus namespace for metrics.
+	Namespace string
+	// Subsystem is the prometheus subsystem for metrics.
+	Subsystem string
+	// ConstLabels are constant labels added to all metrics.
+	ConstLabels prometheus.Labels
+	// InstanceLabels are the variable labels for this cache instance.
+	// Example: {"cache_type": "session", "region": "us-east"}
+	// The keys will be used as label names, values as label values.
+	InstanceLabels map[string]string
+	// UpdateInterval controls how often metrics are updated.
+	// If 0, defaults to 5 seconds.
+	UpdateInterval time.Duration
+	// Registerer is the prometheus registerer to use.
+	// If nil, the default registerer is used.
+	Registerer prometheus.Registerer
+}
+
+// NewMetrics creates a new Metrics instance.
+func NewMetrics(cfg MetricsConfig) *Metrics {
+	if cfg.Subsystem == "" {
+		cfg.Subsystem = "cache"
+	}
+
+	// Extract label names from InstanceLabels map
+	labelNames := make([]string, 0, len(cfg.InstanceLabels))
+	for k := range cfg.InstanceLabels {
+		labelNames = append(labelNames, k)
+	}
+	// Sort to ensure consistent order
+	sort.Strings(labelNames)
+
+	return &Metrics{
+		namespace: cfg.Namespace,
+		subsystem: cfg.Subsystem,
+		labels:    labelNames,
+		insertionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   cfg.Namespace,
+			Subsystem:   cfg.Subsystem,
+			Name:        "insertions_total",
+			Help:        "Total number of cache insertions",
+			ConstLabels: cfg.ConstLabels,
+		}, labelNames),
+		hitsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   cfg.Namespace,
+			Subsystem:   cfg.Subsystem,
+			Name:        "hits_total",
+			Help:        "Total number of cache hits",
+			ConstLabels: cfg.ConstLabels,
+		}, labelNames),
+		missesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   cfg.Namespace,
+			Subsystem:   cfg.Subsystem,
+			Name:        "misses_total",
+			Help:        "Total number of cache misses",
+			ConstLabels: cfg.ConstLabels,
+		}, labelNames),
+		evictionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   cfg.Namespace,
+			Subsystem:   cfg.Subsystem,
+			Name:        "evictions_total",
+			Help:        "Total number of cache evictions",
+			ConstLabels: cfg.ConstLabels,
+		}, labelNames),
+		sizeGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   cfg.Namespace,
+			Subsystem:   cfg.Subsystem,
+			Name:        "size",
+			Help:        "Current number of items in the cache",
+			ConstLabels: cfg.ConstLabels,
+		}, labelNames),
+	}
+}
+
+// Register registers the metrics with the provided registerer.
+// If registerer is nil, the default prometheus registerer is used.
+func (m *Metrics) Register(registerer prometheus.Registerer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registered {
+		return nil
+	}
+
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+
+	collectors := []prometheus.Collector{
+		m.insertionsTotal,
+		m.hitsTotal,
+		m.missesTotal,
+		m.evictionsTotal,
+		m.sizeGauge,
+	}
+
+	for _, c := range collectors {
+		if err := registerer.Register(c); err != nil {
+			// Try to unregister any previously registered collectors
+			for i := 0; i < len(collectors); i++ {
+				registerer.Unregister(collectors[i])
+			}
+
+			return err
+		}
+	}
+
+	m.registered = true
+
+	return nil
+}
+
+// Unregister unregisters the metrics from the provided registerer.
+func (m *Metrics) Unregister(registerer prometheus.Registerer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.registered {
+		return
+	}
+
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+
+	registerer.Unregister(m.insertionsTotal)
+	registerer.Unregister(m.hitsTotal)
+	registerer.Unregister(m.missesTotal)
+	registerer.Unregister(m.evictionsTotal)
+	registerer.Unregister(m.sizeGauge)
+
+	m.registered = false
+}
+
+// IncInsertions increments the insertions counter.
+func (m *Metrics) IncInsertions(labelValues ...string) {
+	m.insertionsTotal.WithLabelValues(labelValues...).Inc()
+}
+
+// IncHits increments the hits counter.
+func (m *Metrics) IncHits(labelValues ...string) {
+	m.hitsTotal.WithLabelValues(labelValues...).Inc()
+}
+
+// IncMisses increments the misses counter.
+func (m *Metrics) IncMisses(labelValues ...string) {
+	m.missesTotal.WithLabelValues(labelValues...).Inc()
+}
+
+// IncEvictions increments the evictions counter.
+func (m *Metrics) IncEvictions(labelValues ...string) {
+	m.evictionsTotal.WithLabelValues(labelValues...).Inc()
+}
+
+// SetSize sets the current cache size.
+func (m *Metrics) SetSize(size float64, labelValues ...string) {
+	m.sizeGauge.WithLabelValues(labelValues...).Set(size)
+}
+
+// ExtractLabelValues extracts label values from a map in the order of registered labels.
+func (m *Metrics) ExtractLabelValues(instanceLabels map[string]string) []string {
+	values := make([]string, len(m.labels))
+	for i, label := range m.labels {
+		values[i] = instanceLabels[label]
+	}
+
+	return values
+}

--- a/pkg/cache/metrics_test.go
+++ b/pkg/cache/metrics_test.go
@@ -1,0 +1,441 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetrics(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   MetricsConfig
+		expected struct {
+			namespace  string
+			subsystem  string
+			labelNames []string
+			labelCount int
+		}
+	}{
+		{
+			name: "with all fields",
+			config: MetricsConfig{
+				Namespace: "test",
+				Subsystem: "cache",
+				InstanceLabels: map[string]string{
+					"cache_type": "session",
+					"region":     "us-east",
+				},
+			},
+			expected: struct {
+				namespace  string
+				subsystem  string
+				labelNames []string
+				labelCount int
+			}{
+				namespace:  "test",
+				subsystem:  "cache",
+				labelNames: []string{"cache_type", "region"},
+				labelCount: 2,
+			},
+		},
+		{
+			name: "with default subsystem",
+			config: MetricsConfig{
+				Namespace: "test",
+				InstanceLabels: map[string]string{
+					"type": "node",
+				},
+			},
+			expected: struct {
+				namespace  string
+				subsystem  string
+				labelNames []string
+				labelCount int
+			}{
+				namespace:  "test",
+				subsystem:  "cache",
+				labelNames: []string{"type"},
+				labelCount: 1,
+			},
+		},
+		{
+			name: "with const labels",
+			config: MetricsConfig{
+				Namespace: "test",
+				ConstLabels: prometheus.Labels{
+					"app": "myapp",
+					"env": "prod",
+				},
+				InstanceLabels: map[string]string{
+					"cache_name": "primary",
+				},
+			},
+			expected: struct {
+				namespace  string
+				subsystem  string
+				labelNames []string
+				labelCount int
+			}{
+				namespace:  "test",
+				subsystem:  "cache",
+				labelNames: []string{"cache_name"},
+				labelCount: 1,
+			},
+		},
+		{
+			name:   "empty config",
+			config: MetricsConfig{},
+			expected: struct {
+				namespace  string
+				subsystem  string
+				labelNames []string
+				labelCount int
+			}{
+				namespace:  "",
+				subsystem:  "cache",
+				labelNames: []string{},
+				labelCount: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMetrics(tt.config)
+
+			assert.Equal(t, tt.expected.namespace, m.namespace)
+			assert.Equal(t, tt.expected.subsystem, m.subsystem)
+			assert.Equal(t, tt.expected.labelCount, len(m.labels))
+
+			// Check label names are sorted
+			assert.Equal(t, tt.expected.labelNames, m.labels)
+		})
+	}
+}
+
+func TestMetrics_Register(t *testing.T) {
+	t.Run("successful registration", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+			InstanceLabels: map[string]string{
+				"cache_name": "test",
+			},
+		}
+
+		m := NewMetrics(config)
+		err := m.Register(registry)
+		assert.NoError(t, err)
+		assert.True(t, m.registered)
+
+		// Use the metrics to ensure they appear in the registry
+		m.IncInsertions("test")
+		m.IncHits("test")
+		m.IncMisses("test")
+		m.IncEvictions("test")
+		m.SetSize(1, "test")
+
+		// Verify metrics are registered
+		mfs, err := registry.Gather()
+		require.NoError(t, err)
+
+		metricNames := make(map[string]bool)
+		for _, mf := range mfs {
+			metricNames[mf.GetName()] = true
+		}
+
+		// Check that our metric families exist
+		assert.True(t, metricNames["test_cache_insertions_total"])
+		assert.True(t, metricNames["test_cache_hits_total"])
+		assert.True(t, metricNames["test_cache_misses_total"])
+		assert.True(t, metricNames["test_cache_evictions_total"])
+		assert.True(t, metricNames["test_cache_size"])
+	})
+
+	t.Run("registration with nil registerer uses default", func(t *testing.T) {
+		// Save and restore default registerer
+		oldReg := prometheus.DefaultRegisterer
+		defer func() { prometheus.DefaultRegisterer = oldReg }()
+
+		registry := prometheus.NewRegistry()
+		prometheus.DefaultRegisterer = registry
+
+		config := MetricsConfig{
+			Namespace: "test2",
+			Subsystem: "cache",
+		}
+
+		m := NewMetrics(config)
+		err := m.Register(nil)
+		assert.NoError(t, err)
+		assert.True(t, m.registered)
+	})
+
+	t.Run("duplicate registration returns error", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+		}
+
+		m1 := NewMetrics(config)
+		m2 := NewMetrics(config)
+
+		err := m1.Register(registry)
+		assert.NoError(t, err)
+
+		err = m2.Register(registry)
+		assert.Error(t, err)
+		assert.False(t, m2.registered)
+	})
+
+	t.Run("multiple register calls are idempotent", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+		}
+
+		m := NewMetrics(config)
+
+		err := m.Register(registry)
+		assert.NoError(t, err)
+		assert.True(t, m.registered)
+
+		// Second registration should succeed (no-op)
+		err = m.Register(registry)
+		assert.NoError(t, err)
+		assert.True(t, m.registered)
+	})
+}
+
+func TestMetrics_Unregister(t *testing.T) {
+	t.Run("successful unregister", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+		}
+
+		m := NewMetrics(config)
+		err := m.Register(registry)
+		require.NoError(t, err)
+
+		m.Unregister(registry)
+		assert.False(t, m.registered)
+
+		// Should be able to register again
+		err = m.Register(registry)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unregister without register is safe", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+		}
+
+		m := NewMetrics(config)
+		// Should not panic
+		m.Unregister(registry)
+		assert.False(t, m.registered)
+	})
+
+	t.Run("unregister with nil registerer", func(t *testing.T) {
+		config := MetricsConfig{
+			Namespace: "test",
+			Subsystem: "cache",
+		}
+
+		m := NewMetrics(config)
+		m.registered = true
+
+		// Should not panic
+		m.Unregister(nil)
+		assert.False(t, m.registered)
+	})
+}
+
+func TestMetrics_Operations(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	config := MetricsConfig{
+		Namespace: "test",
+		Subsystem: "cache",
+		InstanceLabels: map[string]string{
+			"cache_name": "test",
+		},
+	}
+
+	m := NewMetrics(config)
+	err := m.Register(registry)
+	require.NoError(t, err)
+
+	t.Run("IncInsertions", func(t *testing.T) {
+		m.IncInsertions("test")
+		m.IncInsertions("test")
+
+		value := testutil.ToFloat64(m.insertionsTotal.WithLabelValues("test"))
+		assert.Equal(t, float64(2), value)
+	})
+
+	t.Run("IncHits", func(t *testing.T) {
+		m.IncHits("test")
+		m.IncHits("test")
+		m.IncHits("test")
+
+		value := testutil.ToFloat64(m.hitsTotal.WithLabelValues("test"))
+		assert.Equal(t, float64(3), value)
+	})
+
+	t.Run("IncMisses", func(t *testing.T) {
+		m.IncMisses("test")
+
+		value := testutil.ToFloat64(m.missesTotal.WithLabelValues("test"))
+		assert.Equal(t, float64(1), value)
+	})
+
+	t.Run("IncEvictions", func(t *testing.T) {
+		m.IncEvictions("test")
+		m.IncEvictions("test")
+		m.IncEvictions("test")
+		m.IncEvictions("test")
+
+		value := testutil.ToFloat64(m.evictionsTotal.WithLabelValues("test"))
+		assert.Equal(t, float64(4), value)
+	})
+
+	t.Run("SetSize", func(t *testing.T) {
+		m.SetSize(10, "test")
+		value := testutil.ToFloat64(m.sizeGauge.WithLabelValues("test"))
+		assert.Equal(t, float64(10), value)
+
+		m.SetSize(5, "test")
+		value = testutil.ToFloat64(m.sizeGauge.WithLabelValues("test"))
+		assert.Equal(t, float64(5), value)
+	})
+}
+
+func TestMetrics_ExtractLabelValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         []string
+		instanceLabels map[string]string
+		expected       []string
+	}{
+		{
+			name:   "exact match",
+			labels: []string{"cache_type", "region"},
+			instanceLabels: map[string]string{
+				"cache_type": "session",
+				"region":     "us-east",
+			},
+			expected: []string{"session", "us-east"},
+		},
+		{
+			name:   "missing label value",
+			labels: []string{"cache_type", "region"},
+			instanceLabels: map[string]string{
+				"cache_type": "session",
+			},
+			expected: []string{"session", ""},
+		},
+		{
+			name:   "extra labels in map",
+			labels: []string{"cache_type"},
+			instanceLabels: map[string]string{
+				"cache_type": "session",
+				"region":     "us-east",
+				"extra":      "ignored",
+			},
+			expected: []string{"session"},
+		},
+		{
+			name:           "empty labels",
+			labels:         []string{},
+			instanceLabels: map[string]string{"type": "test"},
+			expected:       []string{},
+		},
+		{
+			name:           "nil map",
+			labels:         []string{"type"},
+			instanceLabels: nil,
+			expected:       []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Metrics{labels: tt.labels}
+			result := m.ExtractLabelValues(tt.instanceLabels)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMetrics_LabelOrdering(t *testing.T) {
+	// Test that labels are consistently ordered regardless of map iteration order
+	config := MetricsConfig{
+		Namespace: "test",
+		InstanceLabels: map[string]string{
+			"z_last":   "value1",
+			"a_first":  "value2",
+			"m_middle": "value3",
+		},
+	}
+
+	m1 := NewMetrics(config)
+	m2 := NewMetrics(config)
+
+	// Labels should be sorted alphabetically
+	expectedLabels := []string{"a_first", "m_middle", "z_last"}
+	assert.Equal(t, expectedLabels, m1.labels)
+	assert.Equal(t, expectedLabels, m2.labels)
+
+	// Extract values should maintain the same order
+	values1 := m1.ExtractLabelValues(config.InstanceLabels)
+	values2 := m2.ExtractLabelValues(config.InstanceLabels)
+
+	expectedValues := []string{"value2", "value3", "value1"}
+	assert.Equal(t, expectedValues, values1)
+	assert.Equal(t, expectedValues, values2)
+}
+
+func TestMetrics_ThreadSafety(t *testing.T) {
+	// Test concurrent registration/unregistration
+	registry := prometheus.NewRegistry()
+	config := MetricsConfig{
+		Namespace: "test",
+		Subsystem: "cache",
+	}
+
+	m := NewMetrics(config)
+
+	done := make(chan bool)
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = m.Register(registry)
+			m.Unregister(registry)
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = m.Register(registry)
+			m.Unregister(registry)
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+
+	// Should end in a consistent state
+	assert.False(t, m.registered)
+}


### PR DESCRIPTION
### Usage

```go
// Simple usage
cache := cache.NewDuplicateCache[string, string](log, ttl)

// Or.... advanced usage
config := cache.Config{
    TTL:      5 * time.Minute,
    Metrics: &cache.MetricsConfig{
        Namespace: "xatu",
        Subsystem: "discovery",
        InstanceLabels: map[string]string{
            "cache_type": "session",
            "region":     "us-east",
        },
        UpdateInterval: 10 * time.Second,
        Registerer:     prometheus.DefaultRegisterer,
    },
}

cache := cache.NewDuplicateCacheWithConfig[string, time.Time](log, config)
```
