### PR TITLE
refactor(beacon): beacon setup for generic use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/ethereum/go-ethereum v1.15.11
-	github.com/ethpandaops/beacon v0.60.0
+	github.com/ethpandaops/beacon v0.61.0
 	github.com/ethpandaops/ethereum-package-go v0.4.0
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/go-co-op/gocron/v2 v2.16.2

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/ethereum/go-ethereum v1.15.11 h1:JK73WKeu0WC0O1eyX+mdQAVHUV+UR1a9VB/d
 github.com/ethereum/go-ethereum v1.15.11/go.mod h1:mf8YiHIb0GR4x4TipcvBUPxJLw1mFdmxzoDi11sDRoI=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/ethpandaops/beacon v0.60.0 h1:Qvq/aVlT8PxmmaAFjWDjLu/uW78rezhFd9zy2foTjos=
-github.com/ethpandaops/beacon v0.60.0/go.mod h1:T5HSrqxG8B28AT1zGFs+N/YDfDWMKBdYZX4Cxvjh2Zc=
+github.com/ethpandaops/beacon v0.61.0 h1:uDymnPAqDnu96bWEek0cHApj+yv2eGUIzLe94QQq+MQ=
+github.com/ethpandaops/beacon v0.61.0/go.mod h1:T5HSrqxG8B28AT1zGFs+N/YDfDWMKBdYZX4Cxvjh2Zc=
 github.com/ethpandaops/ethereum-package-go v0.4.0 h1:ItH40F7/TDGAtvSFU2oGUb0Cc95IWGSZLapw/2GFtxk=
 github.com/ethpandaops/ethereum-package-go v0.4.0/go.mod h1:cT6pzGeMN8QdrudoF7Crk7TdopX7FMhyzZfWACsW+GQ=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -149,12 +149,10 @@ func (c *Crawler) Start(ctx context.Context) error {
 	c.node = h
 
 	// Create the beacon node
-	opts := beacon.DefaultOptions()
-	opts = opts.DisablePrometheusMetrics()
-
+	opts := &ethereum.Options{Options: beacon.DefaultOptions()}
+	opts.DisablePrometheusMetrics()
 	opts.HealthCheck.Interval.Duration = time.Second * 3
 	opts.HealthCheck.SuccessfulResponses = 1
-	opts.PrometheusMetrics = false
 	opts.BeaconSubscription.Enabled = true
 	opts.BeaconSubscription.Topics = []string{"head"}
 
@@ -162,7 +160,7 @@ func (c *Crawler) Start(ctx context.Context) error {
 		c.log,
 		"ethcore/crawler",
 		c.config.Beacon,
-		*opts,
+		opts,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create upstream beacon node: %w", err)
@@ -178,7 +176,7 @@ func (c *Crawler) Start(ctx context.Context) error {
 	// - Start node discovery
 	// - Start our node dialer
 	// - Start the crons
-	c.beacon.OnReady(c.ctx, func(ctx context.Context) error {
+	c.beacon.OnReady(func(ctx context.Context) error {
 		c.log.Info("Beacon node is ready")
 
 		operation := func() (string, error) {

--- a/pkg/ethereum/config.go
+++ b/pkg/ethereum/config.go
@@ -8,8 +8,6 @@ type Config struct {
 	BeaconNodeAddress string `yaml:"beaconNodeAddress"`
 	// BeaconNodeHeaders is a map of headers to send to the beacon node.
 	BeaconNodeHeaders map[string]string `yaml:"beaconNodeHeaders"`
-	// BeaconSubscriptions is a list of beacon subscriptions to subscribe to.
-	BeaconSubscriptions *[]string `yaml:"beaconSubscriptions"`
 	// NetworkOverride is an optional network name to use instead of what's reported by the beacon node
 	NetworkOverride string `yaml:"networkOverride,omitempty"`
 }

--- a/pkg/ethereum/options.go
+++ b/pkg/ethereum/options.go
@@ -1,0 +1,11 @@
+package ethereum
+
+import "github.com/ethpandaops/beacon/pkg/beacon"
+
+// Options configures beacon node behavior.
+type Options struct {
+	*beacon.Options
+
+	FetchBeaconCommittees bool
+	FetchProposerDuties   bool
+}

--- a/pkg/testutil/kurtosis/helpers.go
+++ b/pkg/testutil/kurtosis/helpers.go
@@ -86,16 +86,21 @@ func WaitForBeaconNode(ctx context.Context, logger logrus.FieldLogger, beaconURL
 	}
 
 	// Create beacon options with shorter health check interval
-	opts := beacon.DefaultOptions()
-	opts = opts.DisablePrometheusMetrics()
-	opts.HealthCheck.Interval.Duration = 250 * time.Millisecond
+	beaconOpts := beacon.DefaultOptions()
+	beaconOpts = beaconOpts.DisablePrometheusMetrics()
+	beaconOpts.HealthCheck.Interval.Duration = 250 * time.Millisecond
+
+	// Create ethereum options with embedded beacon options
+	ethereumOpts := &ethcoreEthereum.Options{
+		Options: beaconOpts,
+	}
 
 	// Create the beacon node
 	beaconNode, err := ethcoreEthereum.NewBeaconNode(
 		logger,
 		"testing",
 		beaconConfig,
-		*opts,
+		ethereumOpts,
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create beacon node client for %s", name)


### PR DESCRIPTION
refactor(ethereum): introduce `Options` struct to encapsulate beacon options
refactor(ethereum): modify `NewBeaconNode` to accept `*Options` instead of `beacon.Options`
refactor(crawler): update `Crawler` to use new `ethereum.Options` for beacon node
refactor(beacon): remove `PrometheusMetrics` from beacon options as it's handled by `DisablePrometheusMetrics`
refactor(beacon): remove `BeaconSubscriptions` from config as it's now part of `ethereum.Options`
refactor(beacon): update `OnReady` callback to remove `context.Context` parameter
refactor(beacon): remove explicit `logrus.WarnLevel` for beacon logger, use default
test(ethereum): update beacon node tests to use new `ethereum.Options`
test(kurtosis): update kurtosis helpers to use new `ethereum.Options` for beacon node creation