### PR TITLE
fix(crawler): defer unlock of shutdown mutex to prevent race condition

### DIFF
--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -877,7 +877,9 @@ func (c *Crawler) scheduleRetry(peerID peer.ID, peer *discovery.ConnectablePeer,
 
 		return
 	}
-	c.shutdownMu.RUnlock()
+
+	// Keep the lock while sending to race on channel close when shutting down.
+	defer c.shutdownMu.RUnlock()
 
 	// Remove from duplicate cache to allow immediate retry
 	c.duplicateCache.GetCache().Delete(peerID.String())


### PR DESCRIPTION
```
  INFO[0057] Stopping processor
  INFO[0057] Draining queue: waiting for the batch builder to process remaining items
  INFO[0057] Draining queue: waiting for workers to finish processing batches
  INFO[0057] Draining queue: all items processed
  INFO[0057] Stopping worker 0
  INFO[0057] Batch builder exited
  INFO[0057] Stopping duplicate cache                      module=ethcore/cache
  INFO[0057] Duplicate cache stopped                       module=ethcore/cache
  INFO[0057] All active workers finished                   module=discovery/p2p
  panic: send on closed channel

  goroutine 6997 [running]:
  github.com/ethpandaops/ethcore/pkg/consensus/mimicry/crawler.(*Crawler).scheduleRetry(0x140000f0160, {0x1400393ac00, 0x27}, 0x14000a76bd0, 0x140031305a0, {0x104010680, 0x14000af9400})
          /Users/matty/go/pkg/mod/github.com/ethpandaops/ethcore@v0.0.0-20250704053935-1583744db4f0/pkg/consensus/mimicry/crawler/crawler.go:876 +0x3e4
  github.com/ethpandaops/ethcore/pkg/consensus/mimicry/crawler.(*Crawler).handleCrawlFailure(0x140000f0160, {0x1400393ac00, 0x27}, {{0x102f3c986, 0x1a}, {0x102f06126, 0x7}})
          /Users/matty/go/pkg/mod/github.com/ethpandaops/ethcore@v0.0.0-20250704053935-1583744db4f0/pkg/consensus/mimicry/crawler/crawler.go:808 +0x584
  github.com/ethpandaops/ethcore/pkg/consensus/mimicry/crawler.(*Crawler).handlePeerConnected(0x140000f0160, {0x104064ae0?, 0x140016ee400?}, {0x10405e968, 0x14003be4ea0})
          /Users/matty/go/pkg/mod/github.com/ethpandaops/ethcore@v0.0.0-20250704053935-1583744db4f0/pkg/consensus/mimicry/crawler/wiring.go:271 +0x1488
  reflect.Value.call({0x103ab8a00?, 0x14001da5680?, 0x14002a7ae48?}, {0x102f0068c, 0x4}, {0x1400152a120, 0x2, 0x12ce53db0?})
          /opt/homebrew/Cellar/go/1.24.4/libexec/src/reflect/value.go:584 +0x978
  reflect.Value.Call({0x103ab8a00?, 0x14001da5680?, 0x12ce53dd8?}, {0x1400152a120?, 0x103fcc340?, 0x0?})
          /opt/homebrew/Cellar/go/1.24.4/libexec/src/reflect/value.go:368 +0x94
  github.com/chuckpreslar/emission.(*Emitter).Emit.func1({0x103ab8a00?, 0x14001da5680?, 0x0?})
          /Users/matty/go/pkg/mod/github.com/chuckpreslar/emission@v0.0.0-20170206194824-a7ddd980baf9/emitter.go:209 +0x310
  created by github.com/chuckpreslar/emission.(*Emitter).Emit in goroutine 6901
          /Users/matty/go/pkg/mod/github.com/chuckpreslar/emission@v0.0.0-20170206194824-a7ddd980baf9/emitter.go:184 +0x19c
  exit status 2
```