### PR TITLE
feat(crawler): add network ID to successful crawl event

### DIFF
--- a/pkg/consensus/mimicry/crawler/event.go
+++ b/pkg/consensus/mimicry/crawler/event.go
@@ -24,6 +24,7 @@ type SuccessfulCrawl struct {
 	PeerID       peer.ID
 	NodeID       string
 	AgentVersion string
+	NetworkID    uint64
 	ENR          *enode.Node
 	Status       *common.Status
 	Metadata     *common.MetaData

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -282,6 +282,7 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 		PeerID:       conn.RemotePeer(),
 		NodeID:       enr.ID().String(),
 		AgentVersion: agentVersion,
+		NetworkID:    c.beacon.Metadata().GetNetwork().ID,
 		ENR:          enr,
 		Metadata:     metadata,
 		Status:       status,


### PR DESCRIPTION
Adds the network ID to the `SuccessfulCrawl` event to provide more context about the crawled peer's network.