### PR TITLE
feat(crawler): add datetime fields to SuccessfulCrawl event

### DIFF
--- a/pkg/consensus/mimicry/crawler/event.go
+++ b/pkg/consensus/mimicry/crawler/event.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -21,13 +22,15 @@ var (
 )
 
 type SuccessfulCrawl struct {
-	PeerID       peer.ID
-	NodeID       string
-	AgentVersion string
-	NetworkID    uint64
-	ENR          *enode.Node
-	Status       *common.Status
-	Metadata     *common.MetaData
+	PeerID                      peer.ID
+	NodeID                      string
+	AgentVersion                string
+	NetworkID                   uint64
+	ENR                         *enode.Node
+	Status                      *common.Status
+	Metadata                    *common.MetaData
+	FinalizedEpochStartDateTime *time.Time
+	HeadSlotStartDateTime       *time.Time
 }
 
 type FailedCrawl struct {

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -278,14 +278,36 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 
 	enr := c.GetPeerENR(conn.RemotePeer())
 
+	// Calculate datetime values for finalized epoch and head slot
+	var (
+		finalizedEpochStartDateTime *time.Time
+		headSlotStartDateTime       *time.Time
+	)
+
+	if status != nil {
+		wallclock := c.beacon.Node().Wallclock()
+
+		// Calculate finalized epoch start datetime
+		finalizedEpoch := wallclock.Epochs().FromNumber(uint64(status.FinalizedEpoch))
+		startTime := finalizedEpoch.TimeWindow().Start()
+		finalizedEpochStartDateTime = &startTime
+
+		// Calculate head slot start datetime
+		headSlot := wallclock.Slots().FromNumber(uint64(status.HeadSlot))
+		startTime = headSlot.TimeWindow().Start()
+		headSlotStartDateTime = &startTime
+	}
+
 	c.emitSuccessfulCrawl(&SuccessfulCrawl{
-		PeerID:       conn.RemotePeer(),
-		NodeID:       enr.ID().String(),
-		AgentVersion: agentVersion,
-		NetworkID:    c.beacon.Metadata().GetNetwork().ID,
-		ENR:          enr,
-		Metadata:     metadata,
-		Status:       status,
+		PeerID:                      conn.RemotePeer(),
+		NodeID:                      enr.ID().String(),
+		AgentVersion:                agentVersion,
+		NetworkID:                   c.beacon.Metadata().GetNetwork().ID,
+		ENR:                         enr,
+		Metadata:                    metadata,
+		Status:                      status,
+		FinalizedEpochStartDateTime: finalizedEpochStartDateTime,
+		HeadSlotStartDateTime:       headSlotStartDateTime,
 	})
 }
 


### PR DESCRIPTION
The crawler can include this data when emitting successful events, as it has direct access to the beacon node and wallclock. Consumers (eg: discovery) might not have access to it.