### PR TITLE
fix(crawler): race/panic in peer connection handling

### DIFF
--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -119,8 +119,6 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 		return
 	}
 
-	goodbyeReason := eth.GoodbyeReasonClientShutdown
-
 	c.log.WithFields(logrus.Fields{
 		"peer": peerID.String(),
 	}).Info("Peer connected")
@@ -197,17 +195,6 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 	c.duplicateCache.GetCache().Set(peerID.String(), time.Now(), c.config.CooloffDuration)
 	logCtx.WithField("cooloff_duration", c.config.CooloffDuration).Debug("Added peer to duplicate cache")
 
-	defer func() {
-		// Disconnect them regardless of what happens
-		// Use a fresh context with timeout for cleanup
-		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer disconnectCancel()
-
-		if err := c.DisconnectFromPeer(disconnectCtx, conn.RemotePeer(), goodbyeReason); err != nil {
-			logCtx.WithError(err).Error("Failed to disconnect from peer")
-		}
-	}()
-
 	// Request status from peer.
 	statusCtx, statusCancel := context.WithTimeout(c.ctx, 30*time.Second)
 
@@ -234,8 +221,6 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 
 	if status != nil && status.ForkDigest != ourStatus.ForkDigest {
 		// They're on a different fork
-		goodbyeReason = eth.GoodbyeReasonIrrelevantNetwork
-
 		c.handleCrawlFailure(conn.RemotePeer(), ErrCrawlStatusForkDigest.WithDetails(fmt.Sprintf("ours %s != theirs %s", ourStatus.ForkDigest, status.ForkDigest)))
 
 		return
@@ -276,7 +261,19 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 	delete(c.retryTracker, conn.RemotePeer())
 	c.retryMu.Unlock()
 
+	// Check if peer is still connected to prevent race conditions
+	if c.node.Connectedness(conn.RemotePeer()) != network.Connected {
+		c.log.WithField("peer", conn.RemotePeer()).Debug("Peer no longer connected, skipping successful crawl emit")
+
+		return
+	}
+
 	enr := c.GetPeerENR(conn.RemotePeer())
+	if enr == nil {
+		c.log.WithField("peer", conn.RemotePeer()).Debug("ENR not available for peer, skipping successful crawl emit")
+
+		return
+	}
 
 	// Calculate datetime values for finalized epoch and head slot
 	var (
@@ -316,6 +313,11 @@ func (c *Crawler) handlePeerDisconnected(net network.Network, conn network.Conn)
 		"peer":          conn.RemotePeer(),
 		"agent_version": c.GetPeerAgentVersion(conn.RemotePeer()),
 	}).Debug("Disconnected from peer")
+
+	// Clean up ENR storage for naturally disconnected peers
+	c.peerENRsMu.Lock()
+	delete(c.peerENRs, conn.RemotePeer())
+	c.peerENRsMu.Unlock()
 }
 
 //nolint:unused // Will revisit if not-needed.


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x2236f3e]

  goroutine 177370 [running]:
  github.com/ethereum/go-ethereum/p2p/enode.(*Node).ID(...)
      /home/savid/go/pkg/mod/github.com/ethereum/go-ethereum@v1.15.11/p2p/enode/node.go:164
  github.com/ethpandaops/ethcore/pkg/consensus/mimicry/crawler.(*Crawler).handlePeerConnected(0xc00023ec60, {0x37fb0a0?, 0xc000500000?}, {0x37f4830, 0xc0011541b0})
      /home/savid/go/pkg/mod/github.com/ethpandaops/ethcore@v0.0.0-20250714043240-99aba39e37eb/pkg/consensus/mimicry/crawler/wiring.go:303 +0x1b7e
```

1. `handlePeerConnected` used a defer block to disconnect from every peer after processing.
2. The disconnection process deleted the peer's ENR from `c.peerENRs` map
3. libp2p's event system is asynchronous - callbacks could still fire after ENR cleanup but before network state reflected the disconnection
4. When the callback tried to access `enr.ID().String()`, the ENR was already `nil`, causing the panic

```
  handlePeerConnected() starts
  ├── Process peer, store ENR
  ├── defer cleanup() scheduled
  ├── Function exits (success/error)
  ├── defer executes:
  │   ├── delete(c.peerENRs, peerID)  ← ENR deleted
  │   └── network.ClosePeer()         ← Network disconnect starts
  ├── [RACE WINDOW]
  └── libp2p callback fires: handlePeerConnected() called again
      └── enr.ID().String() ← Panic, ENR is nil
```