### PR TITLE
chore: upgrade golangci-lint to v2.4.0 and migrate wsl to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - unconvert
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true
@@ -60,6 +60,10 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -71,7 +75,7 @@ linters:
       - linters:
           - gocritic
           - gosec
-          - wsl
+          - wsl_v5
         path: _test\.go
     paths:
       - third_party$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+golangci-lint 2.4.0

--- a/pkg/cache/duplicate_test.go
+++ b/pkg/cache/duplicate_test.go
@@ -195,8 +195,10 @@ func TestDuplicateCache_StructValues(t *testing.T) {
 	ctx := context.Background()
 	err := cache.Start(ctx)
 	assert.NoError(t, err)
+
 	defer func() {
 		err := cache.Stop()
+
 		assert.NoError(t, err)
 	}()
 

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -197,7 +197,6 @@ func (c *Crawler) Start(ctx context.Context) error {
 				c.log.WithError(err).Warnf("Failed to fetch initial status, retrying in %s", duration)
 			}),
 		}
-
 		if _, err := backoff.Retry(ctx, operation, retryOpts...); err != nil {
 			c.log.WithError(err).Warn("Failed to fetch initial status")
 		}
@@ -346,8 +345,10 @@ func (c *Crawler) Stop(ctx context.Context) error {
 
 		// Wait for dialer workers to finish with timeout
 		dialerDone := make(chan struct{})
+
 		go func() {
 			c.dialerWg.Wait()
+
 			close(dialerDone)
 		}()
 
@@ -416,11 +417,13 @@ func (c *Crawler) startCrons(ctx context.Context) error {
 			func() {
 				// Check if we're shutting down
 				c.shutdownMu.RLock()
+
 				if c.isShutdown {
 					c.shutdownMu.RUnlock()
 
 					return
 				}
+
 				c.shutdownMu.RUnlock()
 
 				// Use a timeout context for the status fetch.
@@ -898,6 +901,7 @@ func (c *Crawler) scheduleRetry(peerID peer.ID, peer *discovery.ConnectablePeer,
 
 	// Check if we're shutting down before sending to channel
 	c.shutdownMu.RLock()
+
 	if c.isShutdown {
 		c.shutdownMu.RUnlock()
 
@@ -905,6 +909,7 @@ func (c *Crawler) scheduleRetry(peerID peer.ID, peer *discovery.ConnectablePeer,
 
 		return
 	}
+
 	c.shutdownMu.RUnlock()
 
 	// Remove from duplicate cache to allow immediate retry

--- a/pkg/consensus/mimicry/crawler/req_handlers.go
+++ b/pkg/consensus/mimicry/crawler/req_handlers.go
@@ -19,6 +19,7 @@ func (c *Crawler) handleStatus(ctx context.Context, stream network.Stream) error
 	})
 
 	start := time.Now()
+
 	defer func() {
 		logCtx.WithField("duration", time.Since(start)).Debug("Handled status message")
 
@@ -92,6 +93,7 @@ func (c *Crawler) handleGoodbye(ctx context.Context, stream network.Stream) erro
 	})
 
 	start := time.Now()
+
 	defer func() {
 		logCtx.WithField("duration", time.Since(start)).Debug("Handled goodbye message")
 
@@ -145,6 +147,7 @@ func (c *Crawler) handlePing(ctx context.Context, stream network.Stream) error {
 	})
 
 	start := time.Now()
+
 	defer func() {
 		logCtx.WithField("duration", time.Since(start)).Debug("Handled ping message")
 
@@ -189,6 +192,7 @@ func (c *Crawler) handleMetadata(ctx context.Context, stream network.Stream) err
 	})
 
 	start := time.Now()
+
 	defer func() {
 		logCtx.WithField("duration", time.Since(start)).Debug("Handled metadata message")
 

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -25,6 +25,7 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 	c.beacon.Node().OnHead(ctx, func(ctx context.Context, event *v1.HeadEvent) error {
 		// If we're shutting down, we're done. Dont process any further.
 		c.shutdownMu.RLock()
+
 		if c.isShutdown {
 			c.shutdownMu.RUnlock()
 
@@ -97,6 +98,7 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 	// Don't process the peer any further if we're shutting down.
 	c.shutdownMu.RLock()
+
 	if c.isShutdown {
 		c.shutdownMu.RUnlock()
 
@@ -104,6 +106,7 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 
 		return
 	}
+
 	c.shutdownMu.RUnlock()
 
 	peerID := conn.RemotePeer()
@@ -392,11 +395,13 @@ func (c *Crawler) startDialer(ctx context.Context) error {
 
 					// Check if we're shutting down before connecting.
 					c.shutdownMu.RLock()
+
 					if c.isShutdown {
 						c.shutdownMu.RUnlock()
 
 						return
 					}
+
 					c.shutdownMu.RUnlock()
 
 					if err := c.ConnectToPeer(c.ctx, node.AddrInfo, node.Enode); err != nil {
@@ -437,11 +442,13 @@ func (c *Crawler) startRetryWorker(ctx context.Context) error {
 
 				// Check if we're shutting down
 				c.shutdownMu.RLock()
+
 				if c.isShutdown {
 					c.shutdownMu.RUnlock()
 
 					return
 				}
+
 				c.shutdownMu.RUnlock()
 
 				// Wait for backoff period
@@ -482,11 +489,13 @@ func (c *Crawler) startRetryWorker(ctx context.Context) error {
 func (c *Crawler) handleNewDiscoveryNode(_ context.Context, node *enode.Node) error {
 	// Dont proceed further if we're shutting down.
 	c.shutdownMu.RLock()
+
 	if c.isShutdown {
 		c.shutdownMu.RUnlock()
 
 		return nil
 	}
+
 	c.shutdownMu.RUnlock()
 
 	enr := ""
@@ -524,11 +533,13 @@ func (c *Crawler) handleNewDiscoveryNode(_ context.Context, node *enode.Node) er
 
 	// Check again if we're shutting down before sending.
 	c.shutdownMu.RLock()
+
 	if c.isShutdown {
 		c.shutdownMu.RUnlock()
 
 		return nil
 	}
+
 	c.shutdownMu.RUnlock()
 
 	select {

--- a/pkg/consensus/mimicry/p2p/eth/examples/attestation_handler.go
+++ b/pkg/consensus/mimicry/p2p/eth/examples/attestation_handler.go
@@ -328,6 +328,7 @@ func (h *AttestationHandler) rotateSubnets(ctx context.Context, forkDigest [4]by
 	for subnet := range h.activeSubnets {
 		currentSubnets = append(currentSubnets, subnet)
 	}
+
 	h.mu.RUnlock()
 
 	// Simulate new duty assignment (in production, get this from beacon node)

--- a/pkg/consensus/mimicry/p2p/pubsub/v1/gossipsub.go
+++ b/pkg/consensus/mimicry/p2p/pubsub/v1/gossipsub.go
@@ -303,7 +303,9 @@ func Subscribe[T any](ctx context.Context, g *Gossipsub, topic *Topic[T]) (*Subs
 
 	go func() {
 		defer g.wg.Done()
+
 		<-subCtx.Done()
+
 		g.removeProcessor(topicName)
 	}()
 
@@ -420,7 +422,9 @@ func (g *Gossipsub) createProcessor(ctx context.Context, topic *Topic[any], hand
 	}
 
 	g.procMutex.Lock()
+
 	g.processors[topic.Name()] = proc
+
 	g.procMutex.Unlock()
 
 	return proc, procCtx, nil
@@ -434,6 +438,7 @@ func (g *Gossipsub) removeProcessor(topicName string) {
 	if exists {
 		delete(g.processors, topicName)
 	}
+
 	g.procMutex.Unlock()
 
 	if exists && proc != nil {
@@ -480,16 +485,20 @@ func (g *Gossipsub) Stop() error {
 
 	// Cancel all subscriptions
 	g.subMutex.Lock()
+
 	for _, sub := range g.subscriptions {
 		sub.Cancel()
 	}
+
 	g.subMutex.Unlock()
 
 	// Stop all processors
 	g.procMutex.Lock()
+
 	for _, proc := range g.processors {
 		proc.stop()
 	}
+
 	g.procMutex.Unlock()
 
 	// Wait for all goroutines to finish

--- a/pkg/consensus/mimicry/p2p/pubsub/v1/subscription.go
+++ b/pkg/consensus/mimicry/p2p/pubsub/v1/subscription.go
@@ -282,6 +282,7 @@ func newProcessor[T any](ctx context.Context, topic *Topic[T], handler *HandlerC
 // start begins processing messages from the subscription.
 func (p *processor[T]) start(ctx context.Context) {
 	p.wg.Add(1)
+
 	go p.run(ctx)
 }
 

--- a/pkg/consensus/mimicry/p2p/req_resp.go
+++ b/pkg/consensus/mimicry/p2p/req_resp.go
@@ -71,6 +71,7 @@ func (r *ReqResp) wrapper(ctx context.Context, handler func(ctx context.Context,
 		}
 
 		start := time.Now()
+
 		defer func() {
 			logCtx.WithField("duration", time.Since(start)).Debug("Handled message")
 		}()

--- a/pkg/discovery/disc_v4.go
+++ b/pkg/discovery/disc_v4.go
@@ -70,10 +70,13 @@ func (d *DiscV4) Start(ctx context.Context) error {
 
 func (d *DiscV4) startListener(ctx context.Context) error {
 	d.mu.Lock()
+
 	if d.listener != nil {
 		d.listener.Close()
+
 		d.listener = nil
 	}
+
 	d.mu.Unlock()
 
 	privKey, err := gcrypto.GenerateKey()
@@ -187,11 +190,13 @@ func (l *ListenerV4) GetLocalNodeID() *enode.ID {
 
 func (d *DiscV4) startCrons(ctx context.Context) error {
 	d.mu.Lock()
+
 	if d.scheduler != nil {
 		d.mu.Unlock()
 
 		return nil
 	}
+
 	d.mu.Unlock()
 
 	c, err := gocron.NewScheduler(gocron.WithLocation(time.Local))

--- a/pkg/discovery/disc_v5.go
+++ b/pkg/discovery/disc_v5.go
@@ -74,10 +74,13 @@ func (d *DiscV5) Start(ctx context.Context) error {
 
 func (d *DiscV5) startListener(ctx context.Context) error {
 	d.mu.Lock()
+
 	if d.listener != nil {
 		d.listener.Close()
+
 		d.listener = nil
 	}
+
 	d.mu.Unlock()
 
 	privKey, err := gcrypto.GenerateKey()
@@ -191,11 +194,13 @@ func (d *DiscV5) OnNodeRecord(ctx context.Context, handler func(ctx context.Cont
 
 func (d *DiscV5) startCrons(ctx context.Context) error {
 	d.mu.Lock()
+
 	if d.scheduler != nil {
 		d.mu.Unlock()
 
 		return nil
 	}
+
 	d.mu.Unlock()
 
 	c, err := gocron.NewScheduler(gocron.WithLocation(time.Local))

--- a/pkg/ethereum/beacon/services/metadata.go
+++ b/pkg/ethereum/beacon/services/metadata.go
@@ -134,7 +134,6 @@ func (m *MetadataService) Start(ctx context.Context) error {
 				m.log.WithError(err).Warnf("Failed to refresh metadata, retrying in %s", duration)
 			}),
 		}
-
 		if _, err := backoff.Retry(ctx, operation, retryOpts...); err != nil {
 			m.log.WithError(err).Warn("Failed to refresh metadata")
 		}

--- a/pkg/ethereum/node/enr/parser.go
+++ b/pkg/ethereum/node/enr/parser.go
@@ -325,8 +325,8 @@ func parseID(node *enode.Node) *string {
 // Returns a pointer to the public key bytes, or nil if not present.
 func parseSecp256k1(node *enode.Node) *[]byte {
 	field := s256raw{}
-	err := node.Record().Load(&field)
 
+	err := node.Record().Load(&field)
 	if err != nil {
 		return nil
 	}
@@ -477,7 +477,6 @@ func parseETH2(node *enode.Node) *[]byte {
 	field := eth2{}
 
 	err := node.Record().Load(&field)
-
 	if err != nil {
 		return nil
 	}
@@ -493,7 +492,6 @@ func parseAttnets(node *enode.Node) *[]byte {
 	field := attnets{}
 
 	err := node.Record().Load(&field)
-
 	if err != nil {
 		return nil
 	}
@@ -509,7 +507,6 @@ func parseSyncnets(node *enode.Node) *[]byte {
 	field := syncnets{}
 
 	err := node.Record().Load(&field)
-
 	if err != nil {
 		return nil
 	}
@@ -525,7 +522,6 @@ func parseCGC(node *enode.Node) *[]byte {
 	field := cgc{}
 
 	err := node.Record().Load(&field)
-
 	if err != nil {
 		return nil
 	}
@@ -541,7 +537,6 @@ func parseNFD(node *enode.Node) *[]byte {
 	field := nfd{}
 
 	err := node.Record().Load(&field)
-
 	if err != nil {
 		return nil
 	}

--- a/pkg/testutil/kurtosis/helpers.go
+++ b/pkg/testutil/kurtosis/helpers.go
@@ -286,6 +286,7 @@ func GetBeaconClientByType(foundation *TestFoundation, epgNetwork network.Networ
 		if strings.ToLower(ct) == targetType {
 			// Verify this client is in the foundation's list
 			foundation.mu.Lock()
+
 			for _, beaconClient := range foundation.BeaconClients {
 				if beaconClient == consensusClient.Name() {
 					foundation.mu.Unlock()


### PR DESCRIPTION
- Replace deprecated wsl linter with wsl_v5 in .golangci.yml
- Add .tool-versions to pin golangci-lint 2.4.0
- Apply wsl_v5 rules: add blank lines after lock/unlock, before return, after defer, and around blocks
- Update exclusion rules to use wsl_v5 instead of wsl