### PR TITLE
feat(mimicry): add eth/68 support and BlockRangeUpdate message handling

### DIFF
--- a/pkg/execution/mimicry/client.go
+++ b/pkg/execution/mimicry/client.go
@@ -242,6 +242,12 @@ func (c *Client) startSession(ctx context.Context) {
 
 				return
 			}
+		case BlockRangeUpdateCode:
+			if err := c.handleBlockRangeUpdate(ctx, code, data); err != nil {
+				c.handleSessionError(ctx, err)
+
+				return
+			}
 		default:
 			c.log.WithField("code", code).Debug("received unhandled message code")
 		}

--- a/pkg/execution/mimicry/message_block_range_update.go
+++ b/pkg/execution/mimicry/message_block_range_update.go
@@ -1,0 +1,45 @@
+// eth protocol block receipts https://github.com/ethereum/devp2p/blob/master/caps/eth.md#blockreceipts-0x06
+package mimicry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BlockRangeUpdateCode = 0x21
+)
+
+type BlockRangeUpdate eth.BlockRangeUpdatePacket
+
+func (msg *BlockRangeUpdate) Code() int { return BlockRangeUpdateCode }
+
+func (c *Client) receiveBlockRangeUpdate(ctx context.Context, data []byte) (*BlockRangeUpdate, error) {
+	s := new(BlockRangeUpdate)
+	if err := rlp.DecodeBytes(data, &s); err != nil {
+		return nil, fmt.Errorf("error decoding block range update: %w", err)
+	}
+
+	return s, nil
+}
+
+func (c *Client) handleBlockRangeUpdate(ctx context.Context, code uint64, data []byte) error {
+	c.log.WithField("code", code).Debug("received BlockRangeUpdate")
+
+	blockRangeUpdate, err := c.receiveBlockRangeUpdate(ctx, data)
+	if err != nil {
+		return err
+	}
+
+	c.log.WithFields(logrus.Fields{
+		"earliest_block":    blockRangeUpdate.EarliestBlock,
+		"latest_block":      blockRangeUpdate.LatestBlock,
+		"latest_block_hash": blockRangeUpdate.LatestBlockHash,
+	}).Debug("received BlockRangeUpdate")
+
+	return nil
+}

--- a/pkg/execution/mimicry/message_get_receipts.go
+++ b/pkg/execution/mimicry/message_get_receipts.go
@@ -37,10 +37,25 @@ func (c *Client) handleGetReceipts(ctx context.Context, code uint64, data []byte
 		return err
 	}
 
-	err = c.sendReceipts(ctx, &Receipts{
-		RequestId: blockBodies.RequestId,
-		List:      []*eth.ReceiptList69{eth.NewReceiptList69([]*types.Receipt{})},
-	})
+	var receipts Receipts
+	if c.ethCapVersion == 68 {
+		receipts = &Receipts68{
+			ReceiptsPacket: eth.ReceiptsPacket[*eth.ReceiptList68]{
+				RequestId: blockBodies.RequestId,
+				List:      []*eth.ReceiptList68{eth.NewReceiptList68([]*types.Receipt{})},
+			},
+		}
+	} else {
+		// Default to eth/69
+		receipts = &Receipts69{
+			ReceiptsPacket: eth.ReceiptsPacket[*eth.ReceiptList69]{
+				RequestId: blockBodies.RequestId,
+				List:      []*eth.ReceiptList69{eth.NewReceiptList69([]*types.Receipt{})},
+			},
+		}
+	}
+
+	err = c.sendReceipts(ctx, receipts)
 	if err != nil {
 		c.handleSessionError(ctx, err)
 

--- a/pkg/execution/mimicry/message_status.go
+++ b/pkg/execution/mimicry/message_status.go
@@ -14,28 +14,67 @@ const (
 	StatusCode = 0x10
 )
 
-type Status eth.StatusPacket69
+// Status is a wrapper interface for both StatusPacket68 and StatusPacket69.
+type Status interface {
+	Code() int
+	ReqID() uint64
+}
 
-func (msg *Status) Code() int { return StatusCode }
+type Status68 struct {
+	eth.StatusPacket68
+}
 
-func (msg *Status) ReqID() uint64 { return 0 }
+type Status69 struct {
+	eth.StatusPacket69
+}
 
-func (c *Client) receiveStatus(ctx context.Context, data []byte) (*Status, error) {
-	s := new(Status)
-	if err := rlp.DecodeBytes(data, &s); err != nil {
-		return nil, fmt.Errorf("error decoding status: %w", err)
+func (msg *Status68) Code() int { return StatusCode }
+
+func (msg *Status68) ReqID() uint64 { return 0 }
+
+func (msg *Status69) Code() int { return StatusCode }
+
+func (msg *Status69) ReqID() uint64 { return 0 }
+
+func (c *Client) receiveStatus(ctx context.Context, data []byte) (Status, error) {
+	if c.ethCapVersion == 68 {
+		s := new(Status68)
+		if err := rlp.DecodeBytes(data, &s.StatusPacket68); err != nil {
+			return nil, fmt.Errorf("error decoding status68: %w", err)
+		}
+
+		return s, nil
+	}
+
+	// Default to eth/69
+	s := new(Status69)
+	if err := rlp.DecodeBytes(data, &s.StatusPacket69); err != nil {
+		return nil, fmt.Errorf("error decoding status69: %w", err)
 	}
 
 	return s, nil
 }
 
-func (c *Client) sendStatus(ctx context.Context, status *Status) error {
+func (c *Client) sendStatus(ctx context.Context, status Status) error {
 	c.log.WithFields(logrus.Fields{
-		"code":   StatusCode,
-		"status": status,
+		"code":          StatusCode,
+		"status":        status,
+		"ethCapVersion": c.ethCapVersion,
 	}).Debug("sending Status")
 
-	encodedData, err := rlp.EncodeToBytes(status)
+	var encodedData []byte
+
+	var err error
+
+	switch s := status.(type) {
+	case *Status68:
+		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket68)
+	case *Status69:
+		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket69)
+	default:
+		return fmt.Errorf("unsupported status type: %T", status)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error encoding status: %w", err)
 	}
@@ -48,7 +87,10 @@ func (c *Client) sendStatus(ctx context.Context, status *Status) error {
 }
 
 func (c *Client) handleStatus(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received Status")
+	c.log.WithFields(logrus.Fields{
+		"code":          code,
+		"ethCapVersion": c.ethCapVersion,
+	}).Debug("received Status")
 
 	status, err := c.receiveStatus(ctx, data)
 	if err != nil {

--- a/pkg/execution/mimicry/publish.go
+++ b/pkg/execution/mimicry/publish.go
@@ -20,7 +20,7 @@ func (c *Client) publishHello(ctx context.Context, status *Hello) {
 	c.broker.Emit(topicHello, status)
 }
 
-func (c *Client) publishStatus(ctx context.Context, status *Status) {
+func (c *Client) publishStatus(ctx context.Context, status Status) {
 	c.broker.Emit(topicStatus, status)
 }
 
@@ -50,8 +50,8 @@ func (c *Client) OnHello(ctx context.Context, handler func(ctx context.Context, 
 	})
 }
 
-func (c *Client) OnStatus(ctx context.Context, handler func(ctx context.Context, status *Status) error) {
-	c.broker.On(topicStatus, func(status *Status) {
+func (c *Client) OnStatus(ctx context.Context, handler func(ctx context.Context, status Status) error) {
+	c.broker.On(topicStatus, func(status Status) {
 		c.handleSubscriberError(handler(ctx, status), topicStatus)
 	})
 }


### PR DESCRIPTION
- Add support for both eth/68 and eth/69 protocol versions
- Implement BlockRangeUpdate message type and handler
- Update Status and Receipts types to handle both protocol versions
- Maintain backward compatibility with existing eth/69 implementation