### PR TITLE
feat: add P2P event types for gossipsub, libp2p and RPC handlers

### DIFF
--- a/pkg/consensus/p2p/events/gossipsub/attestation.go
+++ b/pkg/consensus/p2p/events/gossipsub/attestation.go
@@ -1,0 +1,72 @@
+package gossipsub
+
+import (
+	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// TraceEventAttestation represents an attestation event.
+type TraceEventAttestation struct {
+	events.TraceEventPayloadMetaData
+	Attestation *ethtypes.Attestation
+}
+
+// TraceEventAttestationElectra represents an Electra attestation event.
+type TraceEventAttestationElectra struct {
+	events.TraceEventPayloadMetaData
+	AttestationElectra *ethtypes.AttestationElectra
+}
+
+// TraceEventSingleAttestation represents a single attestation event.
+type TraceEventSingleAttestation struct {
+	events.TraceEventPayloadMetaData
+	SingleAttestation *ethtypes.SingleAttestation
+}
+
+// TraceEventSignedAggregateAttestationAndProof represents a signed aggregate attestation and proof event.
+type TraceEventSignedAggregateAttestationAndProof struct {
+	events.TraceEventPayloadMetaData
+	SignedAggregateAttestationAndProof *ethtypes.SignedAggregateAttestationAndProof
+}
+
+// TraceEventSignedAggregateAttestationAndProofElectra represents an Electra signed aggregate attestation and proof event.
+type TraceEventSignedAggregateAttestationAndProofElectra struct {
+	events.TraceEventPayloadMetaData
+	SignedAggregateAttestationAndProofElectra *ethtypes.SignedAggregateAttestationAndProofElectra
+}
+
+// TraceEventSignedContributionAndProof represents a signed contribution and proof event.
+type TraceEventSignedContributionAndProof struct {
+	events.TraceEventPayloadMetaData
+	SignedContributionAndProof *ethtypes.SignedContributionAndProof
+}
+
+// TraceEventVoluntaryExit represents a voluntary exit event.
+type TraceEventVoluntaryExit struct {
+	events.TraceEventPayloadMetaData
+	VoluntaryExit *ethtypes.VoluntaryExit
+}
+
+// TraceEventSyncCommitteeMessage represents a sync committee message event.
+type TraceEventSyncCommitteeMessage struct {
+	events.TraceEventPayloadMetaData
+	SyncCommitteeMessage *ethtypes.SyncCommitteeMessage //nolint:staticcheck // SA1019 gRPC API deprecated but still supported until v8 (2026)
+}
+
+// TraceEventBLSToExecutionChange represents a BLS to execution change event.
+type TraceEventBLSToExecutionChange struct {
+	events.TraceEventPayloadMetaData
+	BLSToExecutionChange *ethtypes.BLSToExecutionChange
+}
+
+// TraceEventProposerSlashing represents a proposer slashing event.
+type TraceEventProposerSlashing struct {
+	events.TraceEventPayloadMetaData
+	ProposerSlashing *ethtypes.ProposerSlashing
+}
+
+// TraceEventAttesterSlashing represents an attester slashing event.
+type TraceEventAttesterSlashing struct {
+	events.TraceEventPayloadMetaData
+	AttesterSlashing *ethtypes.AttesterSlashing
+}

--- a/pkg/consensus/p2p/events/gossipsub/beacon_block.go
+++ b/pkg/consensus/p2p/events/gossipsub/beacon_block.go
@@ -1,0 +1,48 @@
+package gossipsub
+
+import (
+	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// TraceEventPhase0Block represents a Phase0 beacon block event.
+type TraceEventPhase0Block struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlock
+}
+
+// TraceEventAltairBlock represents an Altair beacon block event.
+type TraceEventAltairBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockAltair
+}
+
+// TraceEventBellatrixBlock represents a Bellatrix beacon block event.
+type TraceEventBellatrixBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockBellatrix
+}
+
+// TraceEventCapellaBlock represents a Capella beacon block event.
+type TraceEventCapellaBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockCapella
+}
+
+// TraceEventDenebBlock represents a Deneb beacon block event.
+type TraceEventDenebBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockDeneb
+}
+
+// TraceEventElectraBlock represents an Electra beacon block event.
+type TraceEventElectraBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockElectra
+}
+
+// TraceEventFuluBlock represents a Fulu beacon block event.
+type TraceEventFuluBlock struct {
+	events.TraceEventPayloadMetaData
+	Block *ethtypes.SignedBeaconBlockFulu
+}

--- a/pkg/consensus/p2p/events/gossipsub/blob_sidecar.go
+++ b/pkg/consensus/p2p/events/gossipsub/blob_sidecar.go
@@ -1,0 +1,12 @@
+package gossipsub
+
+import (
+	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// TraceEventBlobSidecar represents a blob sidecar event.
+type TraceEventBlobSidecar struct {
+	events.TraceEventPayloadMetaData
+	BlobSidecar *ethtypes.BlobSidecar
+}

--- a/pkg/consensus/p2p/events/gossipsub/data_column.go
+++ b/pkg/consensus/p2p/events/gossipsub/data_column.go
@@ -1,0 +1,12 @@
+package gossipsub
+
+import (
+	ethtypes "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// TraceEventDataColumnSidecar represents a data column sidecar event.
+type TraceEventDataColumnSidecar struct {
+	events.TraceEventPayloadMetaData
+	DataColumnSidecar *ethtypes.DataColumnSidecar
+}

--- a/pkg/consensus/p2p/events/libp2p/core.go
+++ b/pkg/consensus/p2p/events/libp2p/core.go
@@ -1,0 +1,53 @@
+//nolint:tagliatelle // upstream json tag expectations.
+package libp2p
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+)
+
+// Core libp2p event types that don't come from pubsub
+
+// AddPeerEvent represents a peer being added to the network.
+type AddPeerEvent struct {
+	PeerID   peer.ID     `json:"PeerID"`
+	Protocol protocol.ID `json:"Protocol"`
+}
+
+// RemovePeerEvent represents a peer being removed from the network.
+type RemovePeerEvent struct {
+	PeerID peer.ID `json:"PeerID"`
+}
+
+// ConnectedEvent represents a peer connection event.
+type ConnectedEvent struct {
+	RemotePeer   peer.ID  `json:"RemotePeer"`
+	RemoteMaddrs []string `json:"RemoteMaddrs"`
+}
+
+// DisconnectedEvent represents a peer disconnection event.
+type DisconnectedEvent struct {
+	RemotePeer peer.ID `json:"RemotePeer"`
+}
+
+// JoinEvent represents joining a pubsub topic.
+type JoinEvent struct {
+	Topic string `json:"Topic"`
+}
+
+// LeaveEvent represents leaving a pubsub topic.
+type LeaveEvent struct {
+	Topic string `json:"Topic"`
+}
+
+// GraftEvent represents grafting a peer to a topic.
+type GraftEvent struct {
+	PeerID peer.ID `json:"PeerID"`
+	Topic  string  `json:"Topic"`
+}
+
+// PruneEvent represents pruning a peer from a topic.
+type PruneEvent struct {
+	PeerID peer.ID `json:"PeerID"`
+	Topic  string  `json:"Topic"`
+}

--- a/pkg/consensus/p2p/events/libp2p/trace.go
+++ b/pkg/consensus/p2p/events/libp2p/trace.go
@@ -1,0 +1,23 @@
+package libp2p
+
+// Protocol-level trace events (ADD_PEER, RECV_RPC, etc.)
+
+const (
+	// Event type constants matching the original hermes implementation.
+	EventTypeAddPeer              = "ADD_PEER"
+	EventTypeRemovePeer           = "REMOVE_PEER"
+	EventTypeJoin                 = "JOIN"
+	EventTypeLeave                = "LEAVE"
+	EventTypeGraft                = "GRAFT"
+	EventTypePrune                = "PRUNE"
+	EventTypeValidateMessage      = "VALIDATE_MESSAGE"
+	EventTypeDeliverMessage       = "DELIVER_MESSAGE"
+	EventTypeRejectMessage        = "REJECT_MESSAGE"
+	EventTypeDuplicateMessage     = "DUPLICATE_MESSAGE"
+	EventTypeThrottlePeer         = "THROTTLE_PEER"
+	EventTypeRecvRPC              = "RECV_RPC"
+	EventTypeSendRPC              = "SEND_RPC"
+	EventTypeDropRPC              = "DROP_RPC"
+	EventTypeUndeliverableMessage = "UNDELIVERABLE_MESSAGE"
+	EventTypePublishMessage       = "PUBLISH_MESSAGE"
+)

--- a/pkg/consensus/p2p/events/rpc/handlers.go
+++ b/pkg/consensus/p2p/events/rpc/handlers.go
@@ -1,0 +1,39 @@
+//nolint:tagliatelle // upstream json tag expectations.
+package rpc
+
+// RPC event handler types for processing RPC messages
+
+// HandleStatusEvent represents a status message handler event.
+type HandleStatusEvent struct {
+	PeerID string `json:"PeerID"`
+}
+
+// HandleGoodbyeEvent represents a goodbye message handler event.
+type HandleGoodbyeEvent struct {
+	PeerID string `json:"PeerID"`
+	Reason uint64 `json:"Reason"`
+}
+
+// HandlePingEvent represents a ping message handler event.
+type HandlePingEvent struct {
+	PeerID string `json:"PeerID"`
+	SeqNum uint64 `json:"SeqNum"`
+}
+
+// HandleMetadataEvent represents a metadata message handler event.
+type HandleMetadataEvent struct {
+	PeerID string `json:"PeerID"`
+}
+
+// HandleBlocksByRangeEvent represents a blocks by range request handler event.
+type HandleBlocksByRangeEvent struct {
+	PeerID string `json:"PeerID"`
+	Start  uint64 `json:"Start"`
+	Count  uint64 `json:"Count"`
+}
+
+// HandleBlocksByRootEvent represents a blocks by root request handler event.
+type HandleBlocksByRootEvent struct {
+	PeerID string   `json:"PeerID"`
+	Roots  []string `json:"Roots"`
+}

--- a/pkg/consensus/p2p/events/rpc/types.go
+++ b/pkg/consensus/p2p/events/rpc/types.go
@@ -1,0 +1,62 @@
+//nolint:tagliatelle // upstream json tag expectations.
+package rpc
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// RpcMeta represents RPC metadata.
+type RpcMeta struct {
+	PeerID        peer.ID
+	Subscriptions []RpcMetaSub    `json:"Subs,omitempty"`
+	Messages      []RpcMetaMsg    `json:"Msgs,omitempty"`
+	Control       *RpcMetaControl `json:"Control,omitempty"`
+}
+
+// RpcMetaSub represents RPC subscription metadata.
+type RpcMetaSub struct {
+	Subscribe bool
+	TopicID   string
+}
+
+// RpcMetaMsg represents RPC message metadata.
+type RpcMetaMsg struct {
+	MsgID string `json:"MsgID,omitempty"`
+	Topic string `json:"Topic,omitempty"`
+}
+
+// RpcMetaControl represents RPC control message metadata.
+type RpcMetaControl struct {
+	IHave     []RpcControlIHave     `json:"IHave,omitempty"`
+	IWant     []RpcControlIWant     `json:"IWant,omitempty"`
+	Graft     []RpcControlGraft     `json:"Graft,omitempty"`
+	Prune     []RpcControlPrune     `json:"Prune,omitempty"`
+	Idontwant []RpcControlIdontWant `json:"Idontwant,omitempty"`
+}
+
+// RpcControlIHave represents an IHAVE control message.
+type RpcControlIHave struct {
+	TopicID string
+	MsgIDs  []string
+}
+
+// RpcControlIWant represents an IWANT control message.
+type RpcControlIWant struct {
+	MsgIDs []string
+}
+
+// RpcControlGraft represents a GRAFT control message.
+type RpcControlGraft struct {
+	TopicID string
+}
+
+// RpcControlPrune represents a PRUNE control message.
+type RpcControlPrune struct {
+	TopicID string
+	PeerIDs []peer.ID
+}
+
+// RpcControlIdontWant represents an IDONTWANT control message.
+type RpcControlIdontWant struct {
+	MsgIDs []string
+}

--- a/pkg/consensus/p2p/events/types.go
+++ b/pkg/consensus/p2p/events/types.go
@@ -1,0 +1,38 @@
+//nolint:tagliatelle // upstream json tag expectations.
+package events
+
+import (
+	"strings"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// TraceEvent represents a P2P trace event from the consensus layer.
+type TraceEvent struct {
+	Type      string
+	Topic     string
+	PeerID    peer.ID
+	Timestamp time.Time
+	Payload   any `json:"Data"` // cannot use field "Data" because of gk.Record method
+}
+
+// TraceEventPayloadMetaData represents metadata for P2P message payloads.
+type TraceEventPayloadMetaData struct {
+	PeerID  string `json:"PeerID"`
+	Topic   string `json:"Topic"`
+	Seq     []byte `json:"Seq"`
+	MsgID   string `json:"MsgID"`
+	MsgSize int    `json:"MsgSize"`
+}
+
+// EventTypeFromBeaconChainProtocol returns the event type for a given protocol string.
+func EventTypeFromBeaconChainProtocol(protocol string) string {
+	// Usual protocol string: /eth2/beacon_chain/req/metadata/2/ssz_snappy
+	parts := strings.Split(protocol, "/")
+	if len(parts) > 4 {
+		return "HANDLE_" + strings.ToUpper(parts[4])
+	}
+
+	return "UNKNOWN"
+}

--- a/pkg/consensus/p2p/host/config.go
+++ b/pkg/consensus/p2p/host/config.go
@@ -1,0 +1,51 @@
+package host
+
+// Config represents host configuration.
+type Config struct {
+	// DataStream is the data stream to use for events.
+	DataStream DataStream
+
+	// OutputType specifies the output format for events.
+	OutputType DataStreamOutputType
+
+	// MaxPeers is the maximum number of peers to connect to.
+	MaxPeers int
+
+	// UserAgent is the user agent string to use.
+	UserAgent string
+}
+
+// NewConfig creates a new Config with default values.
+func NewConfig() *Config {
+	return &Config{
+		MaxPeers: 50,
+	}
+}
+
+// WithDataStream sets the data stream for the config.
+func (c *Config) WithDataStream(ds DataStream) *Config {
+	c.DataStream = ds
+
+	return c
+}
+
+// WithOutputType sets the output type for the config.
+func (c *Config) WithOutputType(ot DataStreamOutputType) *Config {
+	c.OutputType = ot
+
+	return c
+}
+
+// WithMaxPeers sets the maximum number of peers for the config.
+func (c *Config) WithMaxPeers(maxPeers int) *Config {
+	c.MaxPeers = maxPeers
+
+	return c
+}
+
+// WithUserAgent sets the user agent for the config.
+func (c *Config) WithUserAgent(userAgent string) *Config {
+	c.UserAgent = userAgent
+
+	return c
+}

--- a/pkg/consensus/p2p/host/interfaces.go
+++ b/pkg/consensus/p2p/host/interfaces.go
@@ -1,0 +1,65 @@
+package host
+
+import (
+	"context"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// DataStream represents an interface for handling data streams.
+type DataStream interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	PutRecord(ctx context.Context, event *events.TraceEvent) error
+	Type() DataStreamType
+	OutputType() DataStreamOutputType
+}
+
+// EventCallback is a function type for handling events.
+type EventCallback func(ctx context.Context, event *events.TraceEvent)
+
+// DataStreamType represents the type of data stream.
+type DataStreamType int
+
+const (
+	// DataStreamTypeKinesis represents a Kinesis data stream.
+	DataStreamTypeKinesis DataStreamType = iota
+	// DataStreamTypeCallback represents a callback-based data stream.
+	DataStreamTypeCallback
+	// DataStreamTypeLogger represents a logger data stream.
+	DataStreamTypeLogger
+	// DataStreamTypeS3 represents an S3 data stream.
+	DataStreamTypeS3
+	// DataStreamTypeNoop represents a no-op data stream.
+	DataStreamTypeNoop
+)
+
+// String returns the string representation of the DataStreamType.
+func (ds DataStreamType) String() string {
+	switch ds {
+	case DataStreamTypeLogger:
+		return "logger"
+	case DataStreamTypeKinesis:
+		return "kinesis"
+	case DataStreamTypeCallback:
+		return "callback"
+	case DataStreamTypeS3:
+		return "s3"
+	case DataStreamTypeNoop:
+		return "noop"
+	default:
+		return "logger"
+	}
+}
+
+// DataStreamOutputType is the output type of the data stream.
+type DataStreamOutputType int
+
+const (
+	// DataStreamOutputTypeKinesis outputs the data stream decorated with metadata and in a format ingested by Kinesis.
+	DataStreamOutputTypeKinesis DataStreamOutputType = iota
+	// DataStreamOutputTypeFull outputs the data stream decorated with metadata and containing the raw/full event data.
+	DataStreamOutputTypeFull
+	// DataStreamOutputTypeParquet outputs the trace events formatted into a simplified parquet columns style.
+	DataStreamOutputTypeParquet
+)

--- a/pkg/consensus/p2p/renderer/renderer.go
+++ b/pkg/consensus/p2p/renderer/renderer.go
@@ -1,0 +1,52 @@
+package renderer
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/encoder"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	ssz "github.com/prysmaticlabs/fastssz"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/p2p/events"
+)
+
+// DataStreamRenderer is an interface to support rendering a data-stream message into a destination.
+type DataStreamRenderer interface {
+	RenderPayload(evt *events.TraceEvent, msg *pubsub.Message, dst ssz.Unmarshaler) (*events.TraceEvent, error)
+}
+
+// FullOutput is a renderer for full output.
+type FullOutput struct {
+	encoder encoder.NetworkEncoding
+}
+
+// NewFullOutput creates a new instance of FullOutput.
+func NewFullOutput(enc encoder.NetworkEncoding) DataStreamRenderer {
+	return &FullOutput{encoder: enc}
+}
+
+// RenderPayload renders message into the destination.
+func (t *FullOutput) RenderPayload(evt *events.TraceEvent, msg *pubsub.Message, dst ssz.Unmarshaler) (*events.TraceEvent, error) {
+	if t.encoder == nil {
+		return nil, fmt.Errorf("no network encoding provided to raw output renderer")
+	}
+
+	if err := t.encoder.DecodeGossip(msg.Data, dst); err != nil {
+		return nil, fmt.Errorf("decode gossip message: %w", err)
+	}
+
+	// The actual rendering logic would go here, converting the decoded message
+	// into the appropriate event type based on the destination type.
+	// For now, we just update the event metadata.
+	evt.Payload = map[string]any{
+		"PeerID":  msg.ReceivedFrom.String(),
+		"Topic":   msg.GetTopic(),
+		"Seq":     hex.EncodeToString(msg.GetSeqno()),
+		"MsgID":   hex.EncodeToString([]byte(msg.ID)),
+		"MsgSize": len(msg.Data),
+		"Data":    dst,
+	}
+
+	return evt, nil
+}

--- a/pkg/consensus/telemetry/interfaces.go
+++ b/pkg/consensus/telemetry/interfaces.go
@@ -1,0 +1,85 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Tracer provides OpenTelemetry tracing capabilities.
+type Tracer interface {
+	// Start creates a new span and returns a context containing the span.
+	Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span)
+
+	// TracerProvider returns the underlying tracer provider.
+	TracerProvider() trace.TracerProvider
+}
+
+// Meter provides OpenTelemetry metrics capabilities.
+type Meter interface {
+	// Int64Counter creates a new int64 counter instrument.
+	Int64Counter(name string, opts ...metric.Int64CounterOption) (metric.Int64Counter, error)
+
+	// Int64Histogram creates a new int64 histogram instrument.
+	Int64Histogram(name string, opts ...metric.Int64HistogramOption) (metric.Int64Histogram, error)
+
+	// Int64UpDownCounter creates a new int64 up-down counter instrument.
+	Int64UpDownCounter(name string, opts ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error)
+
+	// Float64Counter creates a new float64 counter instrument.
+	Float64Counter(name string, opts ...metric.Float64CounterOption) (metric.Float64Counter, error)
+
+	// Float64Histogram creates a new float64 histogram instrument.
+	Float64Histogram(name string, opts ...metric.Float64HistogramOption) (metric.Float64Histogram, error)
+
+	// Float64UpDownCounter creates a new float64 up-down counter instrument.
+	Float64UpDownCounter(name string, opts ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error)
+
+	// RegisterCallback registers a callback that will be called when the meter is read.
+	RegisterCallback(callback metric.Callback, instruments ...metric.Observable) (metric.Registration, error)
+
+	// MeterProvider returns the underlying meter provider.
+	MeterProvider() metric.MeterProvider
+}
+
+// TelemetryProvider provides both tracing and metrics capabilities.
+type TelemetryProvider interface {
+	// Tracer returns a tracer with the given name.
+	Tracer(name string, opts ...trace.TracerOption) Tracer
+
+	// Meter returns a meter with the given name.
+	Meter(name string, opts ...metric.MeterOption) Meter
+
+	// Shutdown gracefully shuts down the telemetry provider.
+	Shutdown(ctx context.Context) error
+}
+
+// Attributes provides common attribute key-value pairs for telemetry.
+type Attributes struct {
+	// Network represents the network name (e.g., "mainnet", "goerli").
+	Network string
+
+	// NodeID represents the node identifier.
+	NodeID string
+
+	// Version represents the software version.
+	Version string
+
+	// Additional custom attributes.
+	Custom []attribute.KeyValue
+}
+
+// ToOTEL converts Attributes to OpenTelemetry attributes.
+func (a Attributes) ToOTEL() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("network", a.Network),
+		attribute.String("node_id", a.NodeID),
+		attribute.String("version", a.Version),
+	}
+
+	attrs = append(attrs, a.Custom...)
+
+	return attrs
+}


### PR DESCRIPTION
Cuts across "hermes" types into `ethcore`.

My thinking around the structure here is below, as we might want to potentially move other re-used types here, eg: beacon api, or execution (one day).

```
  ethcore/
  ├── pkg/
  │   ├── consensus/
  │   │   ├── p2p/
  │   │   │   ├── events/           # P2P/Gossipsub events
  │   │   │   │   ├── types.go      # Core TraceEvent type
  │   │   │   │   ├── gossipsub/    # Gossipsub-specific events
  │   │   │   │   │   ├── beacon_block.go
  │   │   │   │   │   ├── attestation.go
  │   │   │   │   │   ├── blob_sidecar.go
  │   │   │   │   │   └── data_column.go
  │   │   │   │   ├── libp2p/       # Libp2p protocol events
  │   │   │   │   │   ├── core.go   # CONNECTED, DISCONNECTED, etc
  │   │   │   │   │   └── trace.go  # ADD_PEER, RECV_RPC, etc
  │   │   │   │   └── rpc/          # RPC protocol events
  │   │   │   │       ├── types.go   # RpcMeta struct
  │   │   │   │       └── handlers.go # HANDLE_STATUS, HANDLE_METADATA
  │   │   │   ├── host/             # Host interfaces
  │   │   │   └── renderer/         # Event rendering
  │   │   │
  │   │   └── api/                  # Future: Beacon API events
  │   │       └── events/
  │   │           ├── types.go      # HTTP/REST event types
  │   │           ├── validator/    # Validator API events
  │   │           └── beacon/       # Beacon node API events
  │   │
  │   └── execution/
  │       ├── p2p/                  # Future: Execution P2P events (eth/66, etc)
  │       └── api/                  # Future: Engine API events
  │           └── events/
```