### PR TITLE
fix: update mimicry for go-ethereum v1.17.1 (eth/69 only)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
-	github.com/ethereum/go-ethereum v1.17.0
+	github.com/ethereum/go-ethereum v1.17.1
 	github.com/ethpandaops/beacon v0.65.0
 	github.com/ethpandaops/ethereum-package-go v0.8.1
 	github.com/ethpandaops/ethwallclock v0.4.0
@@ -64,7 +64,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
 	github.com/emicklei/dot v1.8.0 // indirect
-	github.com/ethereum/c-kzg-4844/v2 v2.1.5 // indirect
+	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
 	github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/ferranbt/fastssz v0.1.4 // indirect
@@ -201,7 +201,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/supranational/blst v0.3.16-0.20250831170142-f48500c1fdbe // indirect
+	github.com/supranational/blst v0.3.16 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,12 +172,12 @@ github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRr
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum/c-kzg-4844/v2 v2.1.5 h1:aVtoLK5xwJ6c5RiqO8g8ptJ5KU+2Hdquf6G3aXiHh5s=
-github.com/ethereum/c-kzg-4844/v2 v2.1.5/go.mod h1:u59hRTTah4Co6i9fDWtiCjTrblJv0UwsqZKCc0GfgUs=
+github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
+github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
-github.com/ethereum/go-ethereum v1.17.0 h1:2D+1Fe23CwZ5tQoAS5DfwKFNI1HGcTwi65/kRlAVxes=
-github.com/ethereum/go-ethereum v1.17.0/go.mod h1:2W3msvdosS/MCWytpqTcqgFiRYbTH59FxDJzqah120o=
+github.com/ethereum/go-ethereum v1.17.1 h1:IjlQDjgxg2uL+GzPRkygGULPMLzcYWncEI7wbaizvho=
+github.com/ethereum/go-ethereum v1.17.1/go.mod h1:7UWOVHL7K3b8RfVRea022btnzLCaanwHtBuH1jUCH/I=
 github.com/ethpandaops/beacon v0.65.0 h1:ssnab73uiuzhmhtU56q9D3ecVrEYv5n+tuqrXRK4YAg=
 github.com/ethpandaops/beacon v0.65.0/go.mod h1:lgzrJjQVV77wZ+PJymsY3bQbAK4jrtP8n3WOwMf1Pcs=
 github.com/ethpandaops/ethereum-package-go v0.8.1 h1:VN5l8UXveyw7gp0Glj8BRzS/D5RKyvhLeaoi/C5Jy5M=
@@ -884,8 +884,8 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/supranational/blst v0.3.16-0.20250831170142-f48500c1fdbe h1:nbdqkIGOGfUAD54q1s2YBcBz/WcsxCO9HUQ4aGV5hUw=
-github.com/supranational/blst v0.3.16-0.20250831170142-f48500c1fdbe/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jqwYhE=
+github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/pkg/cache/duplicate.go
+++ b/pkg/cache/duplicate.go
@@ -122,7 +122,7 @@ func NewDuplicateCache[K comparable, V any](log logrus.FieldLogger, ttl time.Dur
 
 // Start initializes the cache and begins background cleanup operations.
 func (d *duplicateCache[K, V]) Start(ctx context.Context) error {
-	ctx, d.cancel = context.WithCancel(ctx)
+	ctx, d.cancel = context.WithCancel(ctx) //nolint:gosec // cancel is stored in d.cancel and called in Stop()
 
 	go func() {
 		d.cache.Start()

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -133,7 +133,7 @@ func (c *Crawler) Start(ctx context.Context) error {
 	}).Info("Starting crawler")
 
 	// Create internal context for cancellation
-	c.ctx, c.cancel = context.WithCancel(ctx)
+	c.ctx, c.cancel = context.WithCancel(ctx) //nolint:gosec // cancel is stored in c.cancel and called in Stop()
 
 	// Start the duplicate cache
 	if err := c.duplicateCache.Start(c.ctx); err != nil {

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/protolambda/ztyp/tree"
 	"github.com/sirupsen/logrus"
@@ -597,73 +598,151 @@ func (c *Crawler) DisconnectFromPeer(ctx context.Context, peerID peer.ID, reason
 	return c.node.DisconnectFromPeer(ctx, peerID)
 }
 
+// RequestStatusFromPeer requests the consensus status from a peer.
+// It tries status/2 (Fulu) first, falling back to status/1 if the peer
+// does not support it.
 func (c *Crawler) RequestStatusFromPeer(ctx context.Context, peerID peer.ID) (*common.Status, error) {
 	status := c.GetStatus()
+	statusV2 := eth.StatusV2FromV1(&status)
 
-	req := &p2p.Request{
+	// Try status/2 first.
+	rspV2 := &eth.StatusV2{}
+
+	err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.StatusV2ProtocolID,
+		PeerID:     peerID,
+		Payload:    statusV2,
+		Timeout:    time.Second * 30,
+	}, rspV2)
+	if err == nil {
+		result := rspV2.ToV1()
+		if status.ForkDigest != result.ForkDigest {
+			c.emitPeerStatusUpdated(&PeerStatusUpdated{
+				PeerID: peerID,
+				ENR:    c.GetPeerENR(peerID),
+				Status: result,
+			})
+		}
+
+		return result, nil
+	}
+
+	// Fall back to status/1 if the peer doesn't support status/2.
+	if !isStreamCreationError(err) {
+		c.recordRequestError(eth.StatusV2ProtocolID, err)
+
+		return nil, fmt.Errorf("failed to send status v2 request: %w", err)
+	}
+
+	c.log.WithField("peer", peerID).Debug("Peer does not support status/2, falling back to status/1")
+
+	rspV1 := &common.Status{}
+
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
 		ProtocolID: eth.StatusV1ProtocolID,
 		PeerID:     peerID,
 		Payload:    &status,
 		Timeout:    time.Second * 30,
+	}, rspV1); err != nil {
+		c.recordRequestError(eth.StatusV1ProtocolID, err)
+
+		return nil, fmt.Errorf("failed to send status v1 request: %w", err)
 	}
 
-	rsp := &common.Status{}
-
-	if err := c.reqResp.SendRequest(ctx, req, rsp); err != nil {
-		errType := &p2p.RequestError{}
-
-		if errors.As(err, &errType) {
-			c.metrics.RecordFailedRequest(string(req.ProtocolID), errType.Type)
-
-			return nil, fmt.Errorf("failed to send request: %w", err)
-		}
-
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	if status.ForkDigest != rsp.ForkDigest {
+	if status.ForkDigest != rspV1.ForkDigest {
 		c.emitPeerStatusUpdated(&PeerStatusUpdated{
 			PeerID: peerID,
 			ENR:    c.GetPeerENR(peerID),
-			Status: rsp,
+			Status: rspV1,
 		})
 	}
 
-	return rsp, nil
+	return rspV1, nil
 }
 
+// RequestMetadataFromPeer requests metadata from a peer.
+// It tries metadata/3 (Fulu) first, falling back to metadata/2.
 func (c *Crawler) RequestMetadataFromPeer(ctx context.Context, peerID peer.ID) (*common.MetaData, error) {
 	c.log.WithField("peer", peerID.String()).Debug("Requesting metadata from peer")
 
-	// NOTE: Per the Ethereum consensus spec, metadata requests have NO payload.
-	// We must send nil as the payload to comply with the specification.
-	// See: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#getmetadata-v1
-	req := &p2p.Request{
-		ProtocolID: eth.MetaDataV2ProtocolID,
+	// Try metadata/3 first (no payload per spec).
+	rspV3 := &eth.MetaDataV3{}
+
+	err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.MetaDataV3ProtocolID,
 		PeerID:     peerID,
-		Payload:    nil, // Metadata requests have no payload per spec
+		Payload:    nil,
 		Timeout:    time.Second * 30,
+	}, rspV3)
+	if err == nil {
+		result := rspV3.ToV2()
+
+		c.log.WithFields(logrus.Fields{
+			"peer":                peerID.String(),
+			"seq_number":          result.SeqNumber,
+			"attnets":             fmt.Sprintf("%x", result.Attnets),
+			"custody_group_count": rspV3.CustodyGroupCount,
+		}).Debug("Successfully received metadata v3")
+
+		c.emitMetadataReceived(&MetadataReceived{
+			PeerID:   peerID,
+			ENR:      c.GetPeerENR(peerID),
+			Metadata: result,
+		})
+
+		return result, nil
 	}
 
-	rsp := &common.MetaData{}
+	// Fall back to metadata/2 if the peer doesn't support metadata/3.
+	if !isStreamCreationError(err) {
+		return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
+	}
 
-	if err := c.reqResp.SendRequest(ctx, req, rsp); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+	c.log.WithField("peer", peerID).Debug("Peer does not support metadata/3, falling back to metadata/2")
+
+	rspV2 := &common.MetaData{}
+
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.MetaDataV2ProtocolID,
+		PeerID:     peerID,
+		Payload:    nil,
+		Timeout:    time.Second * 30,
+	}, rspV2); err != nil {
+		return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
 	}
 
 	c.log.WithFields(logrus.Fields{
 		"peer":       peerID.String(),
-		"seq_number": rsp.SeqNumber,
-		"attnets":    fmt.Sprintf("%x", rsp.Attnets),
-	}).Debug("Successfully received metadata")
+		"seq_number": rspV2.SeqNumber,
+		"attnets":    fmt.Sprintf("%x", rspV2.Attnets),
+	}).Debug("Successfully received metadata v2")
 
 	c.emitMetadataReceived(&MetadataReceived{
 		PeerID:   peerID,
 		ENR:      c.GetPeerENR(peerID),
-		Metadata: rsp,
+		Metadata: rspV2,
 	})
 
-	return rsp, nil
+	return rspV2, nil
+}
+
+// isStreamCreationError returns true if the error is a protocol negotiation
+// failure (peer doesn't support the requested protocol version).
+func isStreamCreationError(err error) bool {
+	var reqErr *p2p.RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.Type == p2p.ErrFailedToCreateStream.Type
+	}
+
+	return false
+}
+
+// recordRequestError records a failed request metric if the error is a RequestError.
+func (c *Crawler) recordRequestError(protocolID protocol.ID, err error) {
+	var reqErr *p2p.RequestError
+	if errors.As(err, &reqErr) {
+		c.metrics.RecordFailedRequest(string(protocolID), reqErr.Type)
+	}
 }
 
 func (c *Crawler) GetPeerAgentVersion(peerID peer.ID) string {

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -133,7 +133,7 @@ func (c *Crawler) Start(ctx context.Context) error {
 	}).Info("Starting crawler")
 
 	// Create internal context for cancellation
-	c.ctx, c.cancel = context.WithCancel(ctx) //nolint:gosec // cancel is stored in c.cancel and called in Stop()
+	c.ctx, c.cancel = context.WithCancel(ctx)
 
 	// Start the duplicate cache
 	if err := c.duplicateCache.Start(c.ctx); err != nil {

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -599,150 +599,116 @@ func (c *Crawler) DisconnectFromPeer(ctx context.Context, peerID peer.ID, reason
 }
 
 // RequestStatusFromPeer requests the consensus status from a peer.
-// It tries status/2 (Fulu) first, falling back to status/1 if the peer
-// does not support it.
+// It picks status/2 or status/1 based on the peer's advertised protocols.
 func (c *Crawler) RequestStatusFromPeer(ctx context.Context, peerID peer.ID) (*common.Status, error) {
 	status := c.GetStatus()
-	statusV2 := eth.StatusV2FromV1(&status)
 
-	// Try status/2 first.
-	rspV2 := &eth.StatusV2{}
+	proto, err := c.node.Peerstore().FirstSupportedProtocol(peerID, eth.StatusV2ProtocolID, eth.StatusV1ProtocolID)
+	if err != nil || proto == "" {
+		proto = eth.StatusV1ProtocolID // default to v1 if protocol info unavailable
+	}
 
-	err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.StatusV2ProtocolID,
-		PeerID:     peerID,
-		Payload:    statusV2,
-		Timeout:    time.Second * 30,
-	}, rspV2)
-	if err == nil {
-		result := rspV2.ToV1()
-		if status.ForkDigest != result.ForkDigest {
-			c.emitPeerStatusUpdated(&PeerStatusUpdated{
-				PeerID: peerID,
-				ENR:    c.GetPeerENR(peerID),
-				Status: result,
-			})
+	var result *common.Status
+
+	if proto == eth.StatusV2ProtocolID {
+		statusV2 := eth.StatusV2FromV1(&status)
+		rsp := &eth.StatusV2{}
+
+		if err := c.sendRequest(ctx, proto, peerID, statusV2, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send status v2 request: %w", err)
 		}
 
-		return result, nil
+		result = rsp.ToV1()
+	} else {
+		rsp := &common.Status{}
+
+		if err := c.sendRequest(ctx, proto, peerID, &status, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send status v1 request: %w", err)
+		}
+
+		result = rsp
 	}
 
-	// Fall back to status/1 if the peer doesn't support status/2.
-	if !isStreamCreationError(err) {
-		c.recordRequestError(eth.StatusV2ProtocolID, err)
-
-		return nil, fmt.Errorf("failed to send status v2 request: %w", err)
-	}
-
-	c.log.WithField("peer", peerID).Debug("Peer does not support status/2, falling back to status/1")
-
-	rspV1 := &common.Status{}
-
-	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.StatusV1ProtocolID,
-		PeerID:     peerID,
-		Payload:    &status,
-		Timeout:    time.Second * 30,
-	}, rspV1); err != nil {
-		c.recordRequestError(eth.StatusV1ProtocolID, err)
-
-		return nil, fmt.Errorf("failed to send status v1 request: %w", err)
-	}
-
-	if status.ForkDigest != rspV1.ForkDigest {
+	if status.ForkDigest != result.ForkDigest {
 		c.emitPeerStatusUpdated(&PeerStatusUpdated{
 			PeerID: peerID,
 			ENR:    c.GetPeerENR(peerID),
-			Status: rspV1,
+			Status: result,
 		})
 	}
 
-	return rspV1, nil
+	return result, nil
 }
 
 // RequestMetadataFromPeer requests metadata from a peer.
-// It tries metadata/3 (Fulu) first, falling back to metadata/2.
+// It picks metadata/3 or metadata/2 based on the peer's advertised protocols.
 func (c *Crawler) RequestMetadataFromPeer(ctx context.Context, peerID peer.ID) (*common.MetaData, error) {
 	c.log.WithField("peer", peerID.String()).Debug("Requesting metadata from peer")
 
-	// Try metadata/3 first (no payload per spec).
-	rspV3 := &eth.MetaDataV3{}
+	proto, err := c.node.Peerstore().FirstSupportedProtocol(peerID, eth.MetaDataV3ProtocolID, eth.MetaDataV2ProtocolID)
+	if err != nil || proto == "" {
+		proto = eth.MetaDataV2ProtocolID // default to v2 if protocol info unavailable
+	}
 
-	err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.MetaDataV3ProtocolID,
-		PeerID:     peerID,
-		Payload:    nil,
-		Timeout:    time.Second * 30,
-	}, rspV3)
-	if err == nil {
-		result := rspV3.ToV2()
+	var result *common.MetaData
+
+	if proto == eth.MetaDataV3ProtocolID {
+		rsp := &eth.MetaDataV3{}
+
+		if err := c.sendRequest(ctx, proto, peerID, nil, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
+		}
+
+		result = rsp.ToV2()
 
 		c.log.WithFields(logrus.Fields{
 			"peer":                peerID.String(),
 			"seq_number":          result.SeqNumber,
 			"attnets":             fmt.Sprintf("%x", result.Attnets),
-			"custody_group_count": rspV3.CustodyGroupCount,
+			"custody_group_count": rsp.CustodyGroupCount,
 		}).Debug("Successfully received metadata v3")
+	} else {
+		rsp := &common.MetaData{}
 
-		c.emitMetadataReceived(&MetadataReceived{
-			PeerID:   peerID,
-			ENR:      c.GetPeerENR(peerID),
-			Metadata: result,
-		})
+		if err := c.sendRequest(ctx, proto, peerID, nil, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
+		}
 
-		return result, nil
+		result = rsp
+
+		c.log.WithFields(logrus.Fields{
+			"peer":       peerID.String(),
+			"seq_number": result.SeqNumber,
+			"attnets":    fmt.Sprintf("%x", result.Attnets),
+		}).Debug("Successfully received metadata v2")
 	}
-
-	// Fall back to metadata/2 if the peer doesn't support metadata/3.
-	if !isStreamCreationError(err) {
-		return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
-	}
-
-	c.log.WithField("peer", peerID).Debug("Peer does not support metadata/3, falling back to metadata/2")
-
-	rspV2 := &common.MetaData{}
-
-	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.MetaDataV2ProtocolID,
-		PeerID:     peerID,
-		Payload:    nil,
-		Timeout:    time.Second * 30,
-	}, rspV2); err != nil {
-		return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
-	}
-
-	c.log.WithFields(logrus.Fields{
-		"peer":       peerID.String(),
-		"seq_number": rspV2.SeqNumber,
-		"attnets":    fmt.Sprintf("%x", rspV2.Attnets),
-	}).Debug("Successfully received metadata v2")
 
 	c.emitMetadataReceived(&MetadataReceived{
 		PeerID:   peerID,
 		ENR:      c.GetPeerENR(peerID),
-		Metadata: rspV2,
+		Metadata: result,
 	})
 
-	return rspV2, nil
+	return result, nil
 }
 
-// isStreamCreationError returns true if the error is a protocol negotiation
-// failure (peer doesn't support the requested protocol version).
-func isStreamCreationError(err error) bool {
-	var reqErr *p2p.RequestError
-	if errors.As(err, &reqErr) {
-		return reqErr.Type == p2p.ErrFailedToCreateStream.Type
+// sendRequest sends a request on the given protocol and records metrics on failure.
+func (c *Crawler) sendRequest(ctx context.Context, proto protocol.ID, peerID peer.ID, payload, rsp common.SSZObj) error {
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: proto,
+		PeerID:     peerID,
+		Payload:    payload,
+		Timeout:    time.Second * 30,
+	}, rsp); err != nil {
+		var reqErr *p2p.RequestError
+		if errors.As(err, &reqErr) {
+			c.metrics.RecordFailedRequest(string(proto), reqErr.Type)
+		}
+
+		return err
 	}
 
-	return false
-}
-
-// recordRequestError records a failed request metric if the error is a RequestError.
-func (c *Crawler) recordRequestError(protocolID protocol.ID, err error) {
-	var reqErr *p2p.RequestError
-	if errors.As(err, &reqErr) {
-		c.metrics.RecordFailedRequest(string(protocolID), reqErr.Type)
-	}
+	return nil
 }
 
 func (c *Crawler) GetPeerAgentVersion(peerID peer.ID) string {

--- a/pkg/consensus/mimicry/crawler/req_handlers.go
+++ b/pkg/consensus/mimicry/crawler/req_handlers.go
@@ -82,23 +82,22 @@ func (c *Crawler) readIncomingStatus(
 	stream network.Stream,
 	logCtx *logrus.Entry,
 ) (*common.Status, error) {
+	var (
+		payload common.SSZObj
+		toV1    func() *common.Status
+	)
+
 	if stream.Protocol() == eth.StatusV2ProtocolID {
-		var v2 eth.StatusV2
-		if err := c.reqResp.ReadRequest(ctx, stream, &v2); err != nil {
-			logCtx.WithError(err).Error("Failed to decode status v2 message")
-
-			if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
-				logCtx.WithError(errr).Debug("Failed to send error response")
-			}
-
-			return nil, err
-		}
-
-		return v2.ToV1(), nil
+		v2 := &eth.StatusV2{}
+		payload = v2
+		toV1 = v2.ToV1
+	} else {
+		v1 := &common.Status{}
+		payload = v1
+		toV1 = func() *common.Status { return v1 }
 	}
 
-	var v1 common.Status
-	if err := c.reqResp.ReadRequest(ctx, stream, &v1); err != nil {
+	if err := c.reqResp.ReadRequest(ctx, stream, payload); err != nil {
 		logCtx.WithError(err).Error("Failed to decode status message")
 
 		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
@@ -108,7 +107,7 @@ func (c *Crawler) readIncomingStatus(
 		return nil, err
 	}
 
-	return &v1, nil
+	return toV1(), nil
 }
 
 // writeStatusResponse writes our status in the protocol version the peer used.
@@ -118,18 +117,13 @@ func (c *Crawler) writeStatusResponse(
 	status *common.Status,
 	logCtx *logrus.Entry,
 ) error {
+	var payload common.SSZObj = status
+
 	if stream.Protocol() == eth.StatusV2ProtocolID {
-		v2 := eth.StatusV2FromV1(status)
-		if err := c.reqResp.WriteResponse(ctx, stream, v2, nil); err != nil {
-			logCtx.WithError(err).Debug("Failed to send status v2 response")
-
-			return err
-		}
-
-		return nil
+		payload = eth.StatusV2FromV1(status)
 	}
 
-	if err := c.reqResp.WriteResponse(ctx, stream, status, nil); err != nil {
+	if err := c.reqResp.WriteResponse(ctx, stream, payload, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send status response")
 
 		return err
@@ -263,7 +257,6 @@ func (c *Crawler) handleMetadata(ctx context.Context, stream network.Stream) err
 
 	if stream.Protocol() == eth.MetaDataV3ProtocolID {
 		v3 := eth.MetaDataV3FromV2(c.metadata)
-		v3.CustodyGroupCount = eth.DefaultCustodyGroupCount
 
 		if err := c.reqResp.WriteResponse(ctx, stream, v3, nil); err != nil {
 			logCtx.WithError(err).Debug("Failed to send metadata v3 response")

--- a/pkg/consensus/mimicry/crawler/req_handlers.go
+++ b/pkg/consensus/mimicry/crawler/req_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/sirupsen/logrus"
@@ -28,16 +29,9 @@ func (c *Crawler) handleStatus(ctx context.Context, stream network.Stream) error
 		}
 	}()
 
-	var theirStatus common.Status
-
-	err := c.reqResp.ReadRequest(ctx, stream, &theirStatus)
+	// Decode the incoming status based on the negotiated protocol version.
+	theirStatus, err := c.readIncomingStatus(ctx, stream, logCtx)
 	if err != nil {
-		logCtx.WithError(err).Error("Failed to decode status message")
-
-		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
-			logCtx.WithError(errr).Debug("Failed to send status response in response to decode error")
-		}
-
 		return err
 	}
 
@@ -74,7 +68,68 @@ func (c *Crawler) handleStatus(ctx context.Context, stream network.Stream) error
 		})
 	}
 
-	if err := c.reqResp.WriteResponse(ctx, stream, &status, nil); err != nil {
+	// Respond with our status in the same protocol version the peer used.
+	if err := c.writeStatusResponse(ctx, stream, &status, logCtx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readIncomingStatus decodes a status request from the stream, handling both v1 and v2.
+func (c *Crawler) readIncomingStatus(
+	ctx context.Context,
+	stream network.Stream,
+	logCtx *logrus.Entry,
+) (*common.Status, error) {
+	if stream.Protocol() == eth.StatusV2ProtocolID {
+		var v2 eth.StatusV2
+		if err := c.reqResp.ReadRequest(ctx, stream, &v2); err != nil {
+			logCtx.WithError(err).Error("Failed to decode status v2 message")
+
+			if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
+				logCtx.WithError(errr).Debug("Failed to send error response")
+			}
+
+			return nil, err
+		}
+
+		return v2.ToV1(), nil
+	}
+
+	var v1 common.Status
+	if err := c.reqResp.ReadRequest(ctx, stream, &v1); err != nil {
+		logCtx.WithError(err).Error("Failed to decode status message")
+
+		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
+			logCtx.WithError(errr).Debug("Failed to send error response")
+		}
+
+		return nil, err
+	}
+
+	return &v1, nil
+}
+
+// writeStatusResponse writes our status in the protocol version the peer used.
+func (c *Crawler) writeStatusResponse(
+	ctx context.Context,
+	stream network.Stream,
+	status *common.Status,
+	logCtx *logrus.Entry,
+) error {
+	if stream.Protocol() == eth.StatusV2ProtocolID {
+		v2 := eth.StatusV2FromV1(status)
+		if err := c.reqResp.WriteResponse(ctx, stream, v2, nil); err != nil {
+			logCtx.WithError(err).Debug("Failed to send status v2 response")
+
+			return err
+		}
+
+		return nil
+	}
+
+	if err := c.reqResp.WriteResponse(ctx, stream, status, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send status response")
 
 		return err
@@ -202,14 +257,24 @@ func (c *Crawler) handleMetadata(ctx context.Context, stream network.Stream) err
 		}
 	}()
 
-	// Metadata requests have no content per the Ethereum consensus spec
-	// The request opens and negotiates the stream without sending any request content
-	// We immediately respond with our local metadata
+	// Metadata requests have no content per the Ethereum consensus spec.
+	// Respond with the appropriate version based on the negotiated protocol.
 	logCtx.Debug("Received metadata request")
 
-	resp := c.metadata
+	if stream.Protocol() == eth.MetaDataV3ProtocolID {
+		v3 := eth.MetaDataV3FromV2(c.metadata)
+		v3.CustodyGroupCount = eth.DefaultCustodyGroupCount
 
-	if err := c.reqResp.WriteResponse(ctx, stream, resp, nil); err != nil {
+		if err := c.reqResp.WriteResponse(ctx, stream, v3, nil); err != nil {
+			logCtx.WithError(err).Debug("Failed to send metadata v3 response")
+
+			return err
+		}
+
+		return nil
+	}
+
+	if err := c.reqResp.WriteResponse(ctx, stream, c.metadata, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send metadata response")
 
 		return err

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethpandaops/ethcore/pkg/discovery"
 	"github.com/ethpandaops/ethcore/pkg/ethereum/clients"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -215,6 +216,11 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 
 		logCtx.WithError(err).Debug("Failed to request status from peer")
 
+		// Disconnect from the peer so the retry mechanism can re-dial.
+		// Without this, the peer stays connected and ConnectToPeer's
+		// "already connected" check silently drops subsequent retry attempts.
+		c.disconnectAfterFailure(conn.RemotePeer(), logCtx)
+
 		c.handleCrawlFailure(conn.RemotePeer(), ErrCrawlFailedToRequestStatus)
 
 		return
@@ -253,6 +259,9 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 		}
 
 		logCtx.WithError(err).Debug("Failed to request metadata from peer")
+
+		// Disconnect from the peer so the retry mechanism can re-dial.
+		c.disconnectAfterFailure(conn.RemotePeer(), logCtx)
 
 		c.handleCrawlFailure(conn.RemotePeer(), ErrCrawlFailedToRequestMetadata)
 
@@ -324,6 +333,20 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 			logCtx.WithError(err).Debug("Failed to disconnect from peer after successful crawl")
 		} else {
 			logCtx.Debug("Successfully disconnected from peer after crawl completion")
+		}
+	}
+}
+
+// disconnectAfterFailure disconnects from a peer after a crawl failure so that
+// the retry mechanism can re-dial. Without this, the peer stays connected and
+// ConnectToPeer's "already connected" check silently drops retry attempts.
+func (c *Crawler) disconnectAfterFailure(peerID peer.ID, logCtx *logrus.Entry) {
+	if c.node.Connectedness(peerID) == network.Connected {
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer disconnectCancel()
+
+		if err := c.node.DisconnectFromPeer(disconnectCtx, peerID); err != nil {
+			logCtx.WithError(err).Debug("Failed to disconnect from peer after crawl failure")
 		}
 	}
 }

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -43,7 +43,11 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 
 	// Wire up the req/resp
 	if err := c.reqResp.RegisterHandler(ctx, eth.StatusV1ProtocolID, c.handleStatus); err != nil {
-		return fmt.Errorf("failed to register status handler: %w", err)
+		return fmt.Errorf("failed to register status v1 handler: %w", err)
+	}
+
+	if err := c.reqResp.RegisterHandler(ctx, eth.StatusV2ProtocolID, c.handleStatus); err != nil {
+		return fmt.Errorf("failed to register status v2 handler: %w", err)
 	}
 
 	if err := c.reqResp.RegisterHandler(ctx, eth.GoodbyeV1ProtocolID, c.handleGoodbye); err != nil {
@@ -55,7 +59,11 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 	}
 
 	if err := c.reqResp.RegisterHandler(ctx, eth.MetaDataV2ProtocolID, c.handleMetadata); err != nil {
-		return fmt.Errorf("failed to register metadata handler: %w", err)
+		return fmt.Errorf("failed to register metadata v2 handler: %w", err)
+	}
+
+	if err := c.reqResp.RegisterHandler(ctx, eth.MetaDataV3ProtocolID, c.handleMetadata); err != nil {
+		return fmt.Errorf("failed to register metadata v3 handler: %w", err)
 	}
 
 	// Register dummy RPC handlers for the ones we don't implement yet

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -190,6 +190,9 @@ func (c *Crawler) handlePeerConnected(net network.Network, conn network.Conn) {
 		default:
 		}
 
+		// Disconnect from the peer so the retry mechanism can re-dial.
+		c.disconnectAfterFailure(conn.RemotePeer(), c.log.WithField("peer", conn.RemotePeer()))
+
 		c.handleCrawlFailure(conn.RemotePeer(), ErrCrawlIdentifyTimeout)
 
 		return

--- a/pkg/consensus/mimicry/p2p/eth/metadata.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata.go
@@ -90,12 +90,13 @@ func (m *MetaDataV3) ToV2() *common.MetaData {
 	}
 }
 
-// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3, defaulting CustodyGroupCount to 0.
+// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3,
+// defaulting CustodyGroupCount to DefaultCustodyGroupCount.
 func MetaDataV3FromV2(m *common.MetaData) *MetaDataV3 {
 	return &MetaDataV3{
 		SeqNumber:         m.SeqNumber,
 		Attnets:           m.Attnets,
 		Syncnets:          m.Syncnets,
-		CustodyGroupCount: CustodyGroupCount(0),
+		CustodyGroupCount: DefaultCustodyGroupCount,
 	}
 }

--- a/pkg/consensus/mimicry/p2p/eth/metadata.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata.go
@@ -1,0 +1,101 @@
+package eth
+
+import (
+	"fmt"
+
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/tree"
+	"github.com/protolambda/ztyp/view"
+)
+
+// CustodyGroupCount represents the number of data column custody groups a node participates in.
+type CustodyGroupCount view.Uint64View
+
+// Deserialize implements codec.Deserializable.
+func (c *CustodyGroupCount) Deserialize(dr *codec.DecodingReader) error {
+	return (*view.Uint64View)(c).Deserialize(dr)
+}
+
+// Serialize implements codec.Serializable.
+func (c CustodyGroupCount) Serialize(w *codec.EncodingWriter) error {
+	return w.WriteUint64(uint64(c))
+}
+
+// ByteLength returns the SSZ byte length.
+func (CustodyGroupCount) ByteLength() uint64 { return 8 }
+
+// FixedLength returns the fixed SSZ byte length.
+func (CustodyGroupCount) FixedLength() uint64 { return 8 }
+
+// HashTreeRoot computes the SSZ hash tree root.
+func (c CustodyGroupCount) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return view.Uint64View(c).HashTreeRoot(hFn)
+}
+
+// DefaultCustodyGroupCount is the Fulu spec default for CUSTODY_REQUIREMENT.
+const DefaultCustodyGroupCount CustodyGroupCount = 4
+
+// MetaDataV3 is the Fulu (EIP-7594) version of the eth2 metadata message.
+// It extends MetaData with CustodyGroupCount for PeerDAS.
+type MetaDataV3 struct {
+	SeqNumber         common.SeqNr       `json:"seqNumber" yaml:"seqNumber"`
+	Attnets           common.AttnetBits  `json:"attnets" yaml:"attnets"`
+	Syncnets          common.SyncnetBits `json:"syncnets" yaml:"syncnets"`
+	CustodyGroupCount CustodyGroupCount  `json:"custodyGroupCount" yaml:"custodyGroupCount"`
+}
+
+// MetaDataV3ByteLen is the fixed SSZ byte length of MetaDataV3 (8+8+1+8 = 25).
+const MetaDataV3ByteLen = 8 + 8 + 1 + 8
+
+// Deserialize implements codec.Deserializable.
+func (m *MetaDataV3) Deserialize(dr *codec.DecodingReader) error {
+	return dr.FixedLenContainer(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// Serialize implements codec.Serializable.
+func (m *MetaDataV3) Serialize(w *codec.EncodingWriter) error {
+	return w.FixedLenContainer(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// ByteLength returns the SSZ byte length of MetaDataV3.
+func (m MetaDataV3) ByteLength() uint64 {
+	return MetaDataV3ByteLen
+}
+
+// FixedLength returns the fixed SSZ byte length of MetaDataV3.
+func (*MetaDataV3) FixedLength() uint64 {
+	return MetaDataV3ByteLen
+}
+
+// HashTreeRoot computes the SSZ hash tree root of MetaDataV3.
+func (m *MetaDataV3) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return hFn.HashTreeRoot(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// String returns a human-readable representation of MetaDataV3.
+func (m *MetaDataV3) String() string {
+	return fmt.Sprintf(
+		"MetaDataV3(seq: %d, attnet bits: %08b, syncnet bits: %08b, custody_group_count: %d)",
+		m.SeqNumber, m.Attnets, m.Syncnets, m.CustodyGroupCount,
+	)
+}
+
+// ToV2 converts a MetaDataV3 to a common.MetaData by dropping CustodyGroupCount.
+func (m *MetaDataV3) ToV2() *common.MetaData {
+	return &common.MetaData{
+		SeqNumber: m.SeqNumber,
+		Attnets:   m.Attnets,
+		Syncnets:  m.Syncnets,
+	}
+}
+
+// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3, defaulting CustodyGroupCount to 0.
+func MetaDataV3FromV2(m *common.MetaData) *MetaDataV3 {
+	return &MetaDataV3{
+		SeqNumber:         m.SeqNumber,
+		Attnets:           m.Attnets,
+		Syncnets:          m.Syncnets,
+		CustodyGroupCount: CustodyGroupCount(0),
+	}
+}

--- a/pkg/consensus/mimicry/p2p/eth/metadata_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata_test.go
@@ -69,7 +69,7 @@ func TestMetaDataV3FromV2(t *testing.T) {
 	assert.Equal(t, v2.SeqNumber, v3.SeqNumber)
 	assert.Equal(t, v2.Attnets, v3.Attnets)
 	assert.Equal(t, v2.Syncnets, v3.Syncnets)
-	assert.Equal(t, eth.CustodyGroupCount(0), v3.CustodyGroupCount)
+	assert.Equal(t, eth.DefaultCustodyGroupCount, v3.CustodyGroupCount)
 }
 
 func TestMetaDataV3_RoundTrip(t *testing.T) {

--- a/pkg/consensus/mimicry/p2p/eth/metadata_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata_test.go
@@ -1,0 +1,87 @@
+package eth_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaDataV3_ByteLength(t *testing.T) {
+	m := &eth.MetaDataV3{}
+	assert.Equal(t, uint64(25), m.ByteLength())
+	assert.Equal(t, uint64(25), m.FixedLength())
+}
+
+func TestMetaDataV3_SerializeDeserialize(t *testing.T) {
+	original := &eth.MetaDataV3{
+		SeqNumber:         7,
+		Attnets:           common.AttnetBits{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00},
+		Syncnets:          common.SyncnetBits{0x0f},
+		CustodyGroupCount: 4,
+	}
+
+	// Serialize
+	var buf bytes.Buffer
+	err := original.Serialize(codec.NewEncodingWriter(&buf))
+	require.NoError(t, err)
+	assert.Equal(t, 25, buf.Len())
+
+	// Deserialize
+	decoded := &eth.MetaDataV3{}
+	err = decoded.Deserialize(codec.NewDecodingReader(bytes.NewReader(buf.Bytes()), uint64(buf.Len())))
+	require.NoError(t, err)
+
+	assert.Equal(t, original.SeqNumber, decoded.SeqNumber)
+	assert.Equal(t, original.Attnets, decoded.Attnets)
+	assert.Equal(t, original.Syncnets, decoded.Syncnets)
+	assert.Equal(t, original.CustodyGroupCount, decoded.CustodyGroupCount)
+}
+
+func TestMetaDataV3_ToV2(t *testing.T) {
+	v3 := &eth.MetaDataV3{
+		SeqNumber:         7,
+		Attnets:           common.AttnetBits{0xff},
+		Syncnets:          common.SyncnetBits{0x0f},
+		CustodyGroupCount: 4,
+	}
+
+	v2 := v3.ToV2()
+
+	assert.Equal(t, v3.SeqNumber, v2.SeqNumber)
+	assert.Equal(t, v3.Attnets, v2.Attnets)
+	assert.Equal(t, v3.Syncnets, v2.Syncnets)
+}
+
+func TestMetaDataV3FromV2(t *testing.T) {
+	v2 := &common.MetaData{
+		SeqNumber: 7,
+		Attnets:   common.AttnetBits{0xff},
+		Syncnets:  common.SyncnetBits{0x0f},
+	}
+
+	v3 := eth.MetaDataV3FromV2(v2)
+
+	assert.Equal(t, v2.SeqNumber, v3.SeqNumber)
+	assert.Equal(t, v2.Attnets, v3.Attnets)
+	assert.Equal(t, v2.Syncnets, v3.Syncnets)
+	assert.Equal(t, eth.CustodyGroupCount(0), v3.CustodyGroupCount)
+}
+
+func TestMetaDataV3_RoundTrip(t *testing.T) {
+	original := &common.MetaData{
+		SeqNumber: 42,
+		Attnets:   common.AttnetBits{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+		Syncnets:  common.SyncnetBits{0x0a},
+	}
+
+	// V2 -> V3 -> V2 should preserve all shared fields.
+	v3 := eth.MetaDataV3FromV2(original)
+	result := v3.ToV2()
+
+	assert.Equal(t, original, result)
+}

--- a/pkg/consensus/mimicry/p2p/eth/status.go
+++ b/pkg/consensus/mimicry/p2p/eth/status.go
@@ -1,11 +1,95 @@
 package eth
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/tree"
 )
 
+// PeerStatus associates a peer ID with its consensus status.
 type PeerStatus struct {
 	PeerID peer.ID
 	Status *common.Status
+}
+
+// StatusV2 is the Fulu (EIP-7594) version of the eth2 status message.
+// It extends Status with EarliestAvailableSlot for data availability advertisement.
+type StatusV2 struct {
+	ForkDigest            common.ForkDigest `json:"forkDigest" yaml:"forkDigest"`
+	FinalizedRoot         common.Root       `json:"finalizedRoot" yaml:"finalizedRoot"`
+	FinalizedEpoch        common.Epoch      `json:"finalizedEpoch" yaml:"finalizedEpoch"`
+	HeadRoot              common.Root       `json:"headRoot" yaml:"headRoot"`
+	HeadSlot              common.Slot       `json:"headSlot" yaml:"headSlot"`
+	EarliestAvailableSlot common.Slot       `json:"earliestAvailableSlot" yaml:"earliestAvailableSlot"`
+}
+
+// StatusV2ByteLen is the fixed SSZ byte length of StatusV2 (4+32+8+32+8+8 = 92).
+const StatusV2ByteLen = 4 + 32 + 8 + 32 + 8 + 8
+
+// Deserialize implements codec.Deserializable.
+func (s *StatusV2) Deserialize(dr *codec.DecodingReader) error {
+	return dr.FixedLenContainer(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// Serialize implements codec.Serializable.
+func (s *StatusV2) Serialize(w *codec.EncodingWriter) error {
+	return w.FixedLenContainer(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// ByteLength returns the SSZ byte length of StatusV2.
+func (s StatusV2) ByteLength() uint64 {
+	return StatusV2ByteLen
+}
+
+// FixedLength returns the fixed SSZ byte length of StatusV2.
+func (*StatusV2) FixedLength() uint64 {
+	return StatusV2ByteLen
+}
+
+// HashTreeRoot computes the SSZ hash tree root of StatusV2.
+func (s *StatusV2) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return hFn.HashTreeRoot(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// String returns a human-readable representation of StatusV2.
+func (s *StatusV2) String() string {
+	return fmt.Sprintf(
+		"StatusV2(fork_digest: %s, finalized_root: %s, finalized_epoch: %d, head_root: %s, head_slot: %d, earliest_available_slot: %d)",
+		s.ForkDigest.String(), s.FinalizedRoot.String(), s.FinalizedEpoch, s.HeadRoot.String(), s.HeadSlot, s.EarliestAvailableSlot,
+	)
+}
+
+// ToV1 converts a StatusV2 to a common.Status by dropping EarliestAvailableSlot.
+func (s *StatusV2) ToV1() *common.Status {
+	return &common.Status{
+		ForkDigest:     s.ForkDigest,
+		FinalizedRoot:  s.FinalizedRoot,
+		FinalizedEpoch: s.FinalizedEpoch,
+		HeadRoot:       s.HeadRoot,
+		HeadSlot:       s.HeadSlot,
+	}
+}
+
+// StatusV2FromV1 converts a common.Status to a StatusV2, defaulting EarliestAvailableSlot to 0.
+func StatusV2FromV1(s *common.Status) *StatusV2 {
+	return &StatusV2{
+		ForkDigest:            s.ForkDigest,
+		FinalizedRoot:         s.FinalizedRoot,
+		FinalizedEpoch:        s.FinalizedEpoch,
+		HeadRoot:              s.HeadRoot,
+		HeadSlot:              s.HeadSlot,
+		EarliestAvailableSlot: 0,
+	}
 }

--- a/pkg/consensus/mimicry/p2p/eth/status_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/status_test.go
@@ -1,0 +1,101 @@
+package eth_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusV2_ByteLength(t *testing.T) {
+	s := &eth.StatusV2{}
+	assert.Equal(t, uint64(92), s.ByteLength())
+	assert.Equal(t, uint64(92), s.FixedLength())
+}
+
+func TestStatusV2_SerializeDeserialize(t *testing.T) {
+	original := &eth.StatusV2{
+		ForkDigest:            common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:         common.Root{0xaa},
+		FinalizedEpoch:        42,
+		HeadRoot:              common.Root{0xbb},
+		HeadSlot:              100,
+		EarliestAvailableSlot: 50,
+	}
+
+	// Serialize
+	var buf bytes.Buffer
+	err := original.Serialize(codec.NewEncodingWriter(&buf))
+	require.NoError(t, err)
+	assert.Equal(t, 92, buf.Len())
+
+	// Deserialize
+	decoded := &eth.StatusV2{}
+	err = decoded.Deserialize(codec.NewDecodingReader(bytes.NewReader(buf.Bytes()), uint64(buf.Len())))
+	require.NoError(t, err)
+
+	assert.Equal(t, original.ForkDigest, decoded.ForkDigest)
+	assert.Equal(t, original.FinalizedRoot, decoded.FinalizedRoot)
+	assert.Equal(t, original.FinalizedEpoch, decoded.FinalizedEpoch)
+	assert.Equal(t, original.HeadRoot, decoded.HeadRoot)
+	assert.Equal(t, original.HeadSlot, decoded.HeadSlot)
+	assert.Equal(t, original.EarliestAvailableSlot, decoded.EarliestAvailableSlot)
+}
+
+func TestStatusV2_ToV1(t *testing.T) {
+	v2 := &eth.StatusV2{
+		ForkDigest:            common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:         common.Root{0xaa},
+		FinalizedEpoch:        42,
+		HeadRoot:              common.Root{0xbb},
+		HeadSlot:              100,
+		EarliestAvailableSlot: 50,
+	}
+
+	v1 := v2.ToV1()
+
+	assert.Equal(t, v2.ForkDigest, v1.ForkDigest)
+	assert.Equal(t, v2.FinalizedRoot, v1.FinalizedRoot)
+	assert.Equal(t, v2.FinalizedEpoch, v1.FinalizedEpoch)
+	assert.Equal(t, v2.HeadRoot, v1.HeadRoot)
+	assert.Equal(t, v2.HeadSlot, v1.HeadSlot)
+}
+
+func TestStatusV2FromV1(t *testing.T) {
+	v1 := &common.Status{
+		ForkDigest:     common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:  common.Root{0xaa},
+		FinalizedEpoch: 42,
+		HeadRoot:       common.Root{0xbb},
+		HeadSlot:       100,
+	}
+
+	v2 := eth.StatusV2FromV1(v1)
+
+	assert.Equal(t, v1.ForkDigest, v2.ForkDigest)
+	assert.Equal(t, v1.FinalizedRoot, v2.FinalizedRoot)
+	assert.Equal(t, v1.FinalizedEpoch, v2.FinalizedEpoch)
+	assert.Equal(t, v1.HeadRoot, v2.HeadRoot)
+	assert.Equal(t, v1.HeadSlot, v2.HeadSlot)
+	assert.Equal(t, common.Slot(0), v2.EarliestAvailableSlot)
+}
+
+func TestStatusV2_RoundTrip(t *testing.T) {
+	original := &common.Status{
+		ForkDigest:     common.ForkDigest{0xde, 0xad, 0xbe, 0xef},
+		FinalizedRoot:  common.Root{0x11, 0x22, 0x33},
+		FinalizedEpoch: 999,
+		HeadRoot:       common.Root{0x44, 0x55, 0x66},
+		HeadSlot:       12345,
+	}
+
+	// V1 -> V2 -> V1 should preserve all shared fields.
+	v2 := eth.StatusV2FromV1(original)
+	result := v2.ToV1()
+
+	assert.Equal(t, original, result)
+}

--- a/pkg/consensus/mimicry/p2p/eth/topic.go
+++ b/pkg/consensus/mimicry/p2p/eth/topic.go
@@ -8,16 +8,19 @@ const (
 	ProtocolSuffix    = encoder.ProtocolSuffixSSZSnappy
 	ProtocolVersionV1 = "1"
 	ProtocolVersionV2 = "2"
+	ProtocolVersionV3 = "3"
 )
 
 // Request-Response Protocol IDs.
 const (
 	StatusV1ProtocolID  = "/eth2/beacon_chain/req/status/" + ProtocolVersionV1 + "/" + ProtocolSuffix
+	StatusV2ProtocolID  = "/eth2/beacon_chain/req/status/" + ProtocolVersionV2 + "/" + ProtocolSuffix
 	GoodbyeV1ProtocolID = "/eth2/beacon_chain/req/goodbye/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	PingV1ProtocolID    = "/eth2/beacon_chain/req/ping/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 
 	MetaDataV1ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	MetaDataV2ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV2 + "/" + ProtocolSuffix
+	MetaDataV3ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV3 + "/" + ProtocolSuffix
 
 	BeaconBlocksByRangeV1ProtocolID = "/eth2/beacon_chain/req/beacon_blocks_by_range/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	BeaconBlocksByRangeV2ProtocolID = "/eth2/beacon_chain/req/beacon_blocks_by_range/" + ProtocolVersionV2 + "/" + ProtocolSuffix

--- a/pkg/consensus/mimicry/p2p/pubsub/v1/subscription.go
+++ b/pkg/consensus/mimicry/p2p/pubsub/v1/subscription.go
@@ -265,7 +265,7 @@ func newProcessor[T any](ctx context.Context, topic *Topic[T], handler *HandlerC
 	}
 
 	// Create a cancellable context for this processor
-	procCtx, cancel := context.WithCancel(ctx)
+	procCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is stored in processor.cancel and called on shutdown
 
 	p := &processor[T]{
 		handler:                     handler,

--- a/pkg/ethereum/fork.go
+++ b/pkg/ethereum/fork.go
@@ -23,7 +23,7 @@ func ComputeForkDigest(genesisValidatorsRoot phase0.Root, forkVersion phase0.Ver
 	// For Fulu fork and later, modify the fork digest with blob parameters
 	if blobParams != nil {
 		// serialize epoch and max_blobs_per_block as uint64 little-endian
-		epochBytes := make([]byte, 8)
+		epochBytes := make([]byte, 8, 16)
 		maxBlobsBytes := make([]byte, 8)
 
 		for i := 0; i < 8; i++ {

--- a/pkg/execution/mimicry/constants_test.go
+++ b/pkg/execution/mimicry/constants_test.go
@@ -19,7 +19,7 @@ func TestP2PProtocolVersionConstants(t *testing.T) {
 }
 
 func TestETHProtocolVersionConstants(t *testing.T) {
-	assert.Equal(t, uint(68), minETHProtocolVersion)
+	assert.Equal(t, uint(69), minETHProtocolVersion)
 	assert.Equal(t, uint(69), maxETHProtocolVersion)
 }
 

--- a/pkg/execution/mimicry/message_get_receipts.go
+++ b/pkg/execution/mimicry/message_get_receipts.go
@@ -37,26 +37,13 @@ func (c *Client) handleGetReceipts(ctx context.Context, code uint64, data []byte
 		return err
 	}
 
-	var receipts Receipts
+	pkt := eth.ReceiptsPacket{RequestId: blockBodies.RequestId}
 
-	if c.ethCapVersion == 68 {
-		pkt := eth.ReceiptsPacket[*eth.ReceiptList68]{RequestId: blockBodies.RequestId}
-
-		if appendErr := pkt.List.Append(eth.NewReceiptList68([]*types.Receipt{})); appendErr != nil {
-			return fmt.Errorf("error constructing empty receipts68: %w", appendErr)
-		}
-
-		receipts = &Receipts68{ReceiptsPacket: pkt}
-	} else {
-		// Default to eth/69
-		pkt := eth.ReceiptsPacket[*eth.ReceiptList69]{RequestId: blockBodies.RequestId}
-
-		if appendErr := pkt.List.Append(eth.NewReceiptList69([]*types.Receipt{})); appendErr != nil {
-			return fmt.Errorf("error constructing empty receipts69: %w", appendErr)
-		}
-
-		receipts = &Receipts69{ReceiptsPacket: pkt}
+	if appendErr := pkt.List.Append(eth.NewReceiptList([]*types.Receipt{})); appendErr != nil {
+		return fmt.Errorf("error constructing empty receipts: %w", appendErr)
 	}
+
+	receipts := &Receipts69{ReceiptsPacket: pkt}
 
 	err = c.sendReceipts(ctx, receipts)
 	if err != nil {

--- a/pkg/execution/mimicry/message_hello.go
+++ b/pkg/execution/mimicry/message_hello.go
@@ -15,7 +15,7 @@ const (
 	HelloCode             = 0x00
 	P2PProtocolVersion    = 5
 	minP2PProtocolVersion = 5
-	minETHProtocolVersion = uint(68)
+	minETHProtocolVersion = uint(69)
 	maxETHProtocolVersion = uint(69)
 	ETHCapName            = "eth"
 )
@@ -82,7 +82,7 @@ func (h *Hello) ETHProtocolVersion() uint {
 
 	for _, cap := range h.Caps {
 		if cap.Name == ETHCapName {
-			if cap.Version > highestETHProtocolVersion && cap.Version <= maxETHProtocolVersion {
+			if cap.Version > highestETHProtocolVersion && cap.Version >= minETHProtocolVersion && cap.Version <= maxETHProtocolVersion {
 				highestETHProtocolVersion = cap.Version
 			}
 		}

--- a/pkg/execution/mimicry/message_hello_test.go
+++ b/pkg/execution/mimicry/message_hello_test.go
@@ -28,34 +28,7 @@ func TestHelloValidate(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid hello with ETH 68",
-			hello: &Hello{
-				Version: P2PProtocolVersion,
-				Name:    "test-client",
-				Caps: []p2p.Cap{
-					{Name: ETHCapName, Version: 68},
-				},
-				ListenPort: 30303,
-				ID:         make([]byte, 64),
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid hello with ETH 68 and 69",
-			hello: &Hello{
-				Version: P2PProtocolVersion,
-				Name:    "test-client",
-				Caps: []p2p.Cap{
-					{Name: ETHCapName, Version: 68},
-					{Name: ETHCapName, Version: 69},
-				},
-				ListenPort: 30303,
-				ID:         make([]byte, 64),
-			},
-			wantErr: false,
-		},
-		{
-			name: "ETH 69 only without ETH 68 is invalid",
+			name: "valid hello with ETH 69",
 			hello: &Hello{
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
@@ -65,31 +38,16 @@ func TestHelloValidate(t *testing.T) {
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
 			},
-			wantErr: true,
-			errMsg:  "peer is using unsupported eth protocol version",
-		},
-		{
-			name: "valid hello with multiple ETH versions",
-			hello: &Hello{
-				Version: P2PProtocolVersion,
-				Name:    "test-client",
-				Caps: []p2p.Cap{
-					{Name: ETHCapName, Version: 68},
-					{Name: ETHCapName, Version: 69},
-				},
-				ListenPort: 30303,
-				ID:         make([]byte, 64),
-			},
 			wantErr: false,
 		},
 		{
-			name: "valid hello with mixed capabilities",
+			name: "valid hello with ETH 69 and other caps",
 			hello: &Hello{
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
 				Caps: []p2p.Cap{
 					{Name: "snap", Version: 1},
-					{Name: ETHCapName, Version: 68},
+					{Name: ETHCapName, Version: 69},
 					{Name: "les", Version: 4},
 				},
 				ListenPort: 30303,
@@ -98,12 +56,26 @@ func TestHelloValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "invalid P2P protocol version",
+			name: "ETH 68 only is invalid",
 			hello: &Hello{
-				Version: 4, // Less than minP2PProtocolVersion (5)
+				Version: P2PProtocolVersion,
 				Name:    "test-client",
 				Caps: []p2p.Cap{
 					{Name: ETHCapName, Version: 68},
+				},
+				ListenPort: 30303,
+				ID:         make([]byte, 64),
+			},
+			wantErr: true,
+			errMsg:  "peer is using unsupported eth protocol version",
+		},
+		{
+			name: "invalid P2P protocol version",
+			hello: &Hello{
+				Version: 4,
+				Name:    "test-client",
+				Caps: []p2p.Cap{
+					{Name: ETHCapName, Version: 69},
 				},
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
@@ -144,7 +116,7 @@ func TestHelloValidate(t *testing.T) {
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
 				Caps: []p2p.Cap{
-					{Name: ETHCapName, Version: 67}, // Below minETHProtocolVersion (68)
+					{Name: ETHCapName, Version: 67},
 				},
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
@@ -158,7 +130,7 @@ func TestHelloValidate(t *testing.T) {
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
 				Caps: []p2p.Cap{
-					{Name: ETHCapName, Version: 70}, // Above maxETHProtocolVersion
+					{Name: ETHCapName, Version: 70},
 				},
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
@@ -189,13 +161,6 @@ func TestHelloETHProtocolVersion(t *testing.T) {
 		expected uint
 	}{
 		{
-			name: "ETH 68 only",
-			caps: []p2p.Cap{
-				{Name: ETHCapName, Version: 68},
-			},
-			expected: 68,
-		},
-		{
 			name: "ETH 69 only",
 			caps: []p2p.Cap{
 				{Name: ETHCapName, Version: 69},
@@ -203,17 +168,15 @@ func TestHelloETHProtocolVersion(t *testing.T) {
 			expected: 69,
 		},
 		{
-			name: "ETH 68 and 69 returns highest supported",
+			name: "ETH 68 returns 0 since below min",
 			caps: []p2p.Cap{
 				{Name: ETHCapName, Version: 68},
-				{Name: ETHCapName, Version: 69},
 			},
-			expected: 69,
+			expected: 0,
 		},
 		{
-			name: "ETH 70 unsupported returns max supported 69",
+			name: "ETH 70 unsupported returns 69 if present",
 			caps: []p2p.Cap{
-				{Name: ETHCapName, Version: 68},
 				{Name: ETHCapName, Version: 69},
 				{Name: ETHCapName, Version: 70},
 			},
@@ -243,10 +206,10 @@ func TestHelloETHProtocolVersion(t *testing.T) {
 			name: "mixed caps returns correct ETH version",
 			caps: []p2p.Cap{
 				{Name: "snap", Version: 1},
-				{Name: ETHCapName, Version: 68},
+				{Name: ETHCapName, Version: 69},
 				{Name: "les", Version: 4},
 			},
-			expected: 68,
+			expected: 69,
 		},
 	}
 
@@ -268,17 +231,17 @@ func TestHelloETHCap(t *testing.T) {
 		{
 			name: "returns ETH cap when present",
 			caps: []p2p.Cap{
-				{Name: ETHCapName, Version: 68},
+				{Name: ETHCapName, Version: 69},
 			},
-			expected: &p2p.Cap{Name: ETHCapName, Version: 68},
+			expected: &p2p.Cap{Name: ETHCapName, Version: 69},
 		},
 		{
 			name: "returns first ETH cap when multiple present",
 			caps: []p2p.Cap{
-				{Name: ETHCapName, Version: 68},
 				{Name: ETHCapName, Version: 69},
+				{Name: ETHCapName, Version: 70},
 			},
-			expected: &p2p.Cap{Name: ETHCapName, Version: 68},
+			expected: &p2p.Cap{Name: ETHCapName, Version: 69},
 		},
 		{
 			name: "returns nil when no ETH cap",
@@ -321,13 +284,10 @@ func TestHelloETHCap(t *testing.T) {
 func TestSupportedEthCaps(t *testing.T) {
 	caps := SupportedEthCaps()
 
-	require.Len(t, caps, 2, "should support ETH 68 and 69")
+	require.Len(t, caps, 1, "should support ETH 69 only")
 
 	assert.Equal(t, ETHCapName, caps[0].Name)
-	assert.Equal(t, uint(68), caps[0].Version)
-
-	assert.Equal(t, ETHCapName, caps[1].Name)
-	assert.Equal(t, uint(69), caps[1].Version)
+	assert.Equal(t, uint(69), caps[0].Version)
 }
 
 func TestHelloRLPEncoding(t *testing.T) {
@@ -335,29 +295,24 @@ func TestHelloRLPEncoding(t *testing.T) {
 		Version: P2PProtocolVersion,
 		Name:    "test-client/v1.0.0",
 		Caps: []p2p.Cap{
-			{Name: ETHCapName, Version: 68},
 			{Name: ETHCapName, Version: 69},
 		},
 		ListenPort: 30303,
 		ID:         make([]byte, 64),
 	}
 
-	// Fill ID with recognizable data
 	for i := range original.ID {
 		original.ID[i] = byte(i)
 	}
 
-	// Encode
 	encoded, err := rlp.EncodeToBytes(original)
 	require.NoError(t, err)
 	require.NotEmpty(t, encoded)
 
-	// Decode
 	decoded := new(Hello)
 	err = rlp.DecodeBytes(encoded, decoded)
 	require.NoError(t, err)
 
-	// Verify
 	assert.Equal(t, original.Version, decoded.Version)
 	assert.Equal(t, original.Name, decoded.Name)
 	assert.Equal(t, original.ListenPort, decoded.ListenPort)
@@ -371,12 +326,11 @@ func TestHelloRLPEncoding(t *testing.T) {
 }
 
 func TestHelloRLPEncodingWithRest(t *testing.T) {
-	// Test that the Rest field handles forward compatibility
 	original := &Hello{
 		Version: P2PProtocolVersion,
 		Name:    "test-client",
 		Caps: []p2p.Cap{
-			{Name: ETHCapName, Version: 68},
+			{Name: ETHCapName, Version: 69},
 		},
 		ListenPort: 30303,
 		ID:         make([]byte, 64),

--- a/pkg/execution/mimicry/message_receipts.go
+++ b/pkg/execution/mimicry/message_receipts.go
@@ -14,23 +14,15 @@ const (
 	ReceiptsCode = RLPXOffset + eth.ReceiptsMsg
 )
 
-// Receipts is a wrapper interface for both ReceiptsPacket68 and ReceiptsPacket69.
+// Receipts is a wrapper interface for ReceiptsPacket.
 type Receipts interface {
 	Code() int
 	ReqID() uint64
 }
 
-type Receipts68 struct {
-	eth.ReceiptsPacket[*eth.ReceiptList68]
-}
-
 type Receipts69 struct {
-	eth.ReceiptsPacket[*eth.ReceiptList69]
+	eth.ReceiptsPacket
 }
-
-func (msg *Receipts68) Code() int { return ReceiptsCode }
-
-func (msg *Receipts68) ReqID() uint64 { return msg.RequestId }
 
 func (msg *Receipts69) Code() int { return ReceiptsCode }
 
@@ -46,10 +38,6 @@ func (c *Client) sendReceipts(ctx context.Context, r Receipts) error {
 	var err error
 
 	switch receipts := r.(type) {
-	case *Receipts68:
-		requestID = receipts.RequestId
-		listCount = receipts.List.Len()
-		encodedData, err = rlp.EncodeToBytes(&receipts.ReceiptsPacket)
 	case *Receipts69:
 		requestID = receipts.RequestId
 		listCount = receipts.List.Len()

--- a/pkg/execution/mimicry/message_receipts_test.go
+++ b/pkg/execution/mimicry/message_receipts_test.go
@@ -7,21 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReceipts68Code(t *testing.T) {
-	msg := &Receipts68{}
-	assert.Equal(t, ReceiptsCode, msg.Code())
-	assert.Equal(t, RLPXOffset+eth.ReceiptsMsg, msg.Code())
-}
-
-func TestReceipts68ReqID(t *testing.T) {
-	msg := &Receipts68{
-		ReceiptsPacket: eth.ReceiptsPacket[*eth.ReceiptList68]{
-			RequestId: 55555,
-		},
-	}
-	assert.Equal(t, uint64(55555), msg.ReqID())
-}
-
 func TestReceipts69Code(t *testing.T) {
 	msg := &Receipts69{}
 	assert.Equal(t, ReceiptsCode, msg.Code())
@@ -30,7 +15,7 @@ func TestReceipts69Code(t *testing.T) {
 
 func TestReceipts69ReqID(t *testing.T) {
 	msg := &Receipts69{
-		ReceiptsPacket: eth.ReceiptsPacket[*eth.ReceiptList69]{
+		ReceiptsPacket: eth.ReceiptsPacket{
 			RequestId: 66666,
 		},
 	}
@@ -38,8 +23,6 @@ func TestReceipts69ReqID(t *testing.T) {
 }
 
 func TestReceiptsInterfaceCompliance(t *testing.T) {
-	// Ensure both Receipts68 and Receipts69 implement the Receipts interface
-	var _ Receipts = (*Receipts68)(nil)
 	var _ Receipts = (*Receipts69)(nil)
 }
 
@@ -57,8 +40,6 @@ func TestGetReceiptsReqID(t *testing.T) {
 }
 
 func TestReceiptsCodeConstant(t *testing.T) {
-	// GetReceipts should be 0x1d
 	assert.Equal(t, RLPXOffset+eth.GetReceiptsMsg, GetReceiptsCode)
-	// Receipts should be 0x1e
 	assert.Equal(t, RLPXOffset+eth.ReceiptsMsg, ReceiptsCode)
 }

--- a/pkg/execution/mimicry/message_status.go
+++ b/pkg/execution/mimicry/message_status.go
@@ -14,7 +14,7 @@ const (
 	StatusCode = RLPXOffset + eth.StatusMsg
 )
 
-// Status is a wrapper interface for both StatusPacket68 and StatusPacket69.
+// Status is a wrapper interface for the StatusPacket.
 type Status interface {
 	Code() int
 	ReqID() uint64
@@ -25,27 +25,9 @@ type Status interface {
 	GetForkIDNext() uint64
 }
 
-type Status68 struct {
-	eth.StatusPacket68
-}
-
 type Status69 struct {
-	eth.StatusPacket69
+	eth.StatusPacket
 }
-
-func (msg *Status68) Code() int { return StatusCode }
-
-func (msg *Status68) ReqID() uint64 { return 0 }
-
-func (msg *Status68) GetGenesis() []byte { return msg.Genesis[:] }
-
-func (msg *Status68) GetHead() []byte { return msg.Head[:] }
-
-func (msg *Status68) GetNetworkID() uint64 { return msg.NetworkID }
-
-func (msg *Status68) GetForkIDHash() []byte { return msg.ForkID.Hash[:] }
-
-func (msg *Status68) GetForkIDNext() uint64 { return msg.ForkID.Next }
 
 func (msg *Status69) Code() int { return StatusCode }
 
@@ -62,19 +44,9 @@ func (msg *Status69) GetForkIDHash() []byte { return msg.ForkID.Hash[:] }
 func (msg *Status69) GetForkIDNext() uint64 { return msg.ForkID.Next }
 
 func (c *Client) receiveStatus(ctx context.Context, data []byte) (Status, error) {
-	if c.ethCapVersion == 68 {
-		s := new(Status68)
-		if err := rlp.DecodeBytes(data, &s.StatusPacket68); err != nil {
-			return nil, fmt.Errorf("error decoding status68: %w", err)
-		}
-
-		return s, nil
-	}
-
-	// Default to eth/69
 	s := new(Status69)
-	if err := rlp.DecodeBytes(data, &s.StatusPacket69); err != nil {
-		return nil, fmt.Errorf("error decoding status69: %w", err)
+	if err := rlp.DecodeBytes(data, &s.StatusPacket); err != nil {
+		return nil, fmt.Errorf("error decoding status: %w", err)
 	}
 
 	return s, nil
@@ -92,10 +64,8 @@ func (c *Client) sendStatus(ctx context.Context, status Status) error {
 	var err error
 
 	switch s := status.(type) {
-	case *Status68:
-		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket68)
 	case *Status69:
-		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket69)
+		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket)
 	default:
 		return fmt.Errorf("unsupported status type: %T", status)
 	}

--- a/pkg/execution/mimicry/message_status_test.go
+++ b/pkg/execution/mimicry/message_status_test.go
@@ -14,57 +14,10 @@ import (
 func TestStatusCode(t *testing.T) {
 	expectedCode := RLPXOffset + eth.StatusMsg
 
-	status68 := &Status68{}
-	assert.Equal(t, expectedCode, status68.Code())
-
 	status69 := &Status69{}
 	assert.Equal(t, expectedCode, status69.Code())
 
 	assert.Equal(t, StatusCode, expectedCode)
-}
-
-func TestStatus68Interface(t *testing.T) {
-	genesis := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
-	head := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
-	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
-
-	status := &Status68{
-		StatusPacket68: eth.StatusPacket68{
-			ProtocolVersion: 68,
-			NetworkID:       1,
-			TD:              nil,
-			Head:            head,
-			Genesis:         genesis,
-			ForkID: forkid.ID{
-				Hash: forkIDHash,
-				Next: 1000,
-			},
-		},
-	}
-
-	// Test interface compliance
-	var _ Status = status
-
-	// Test Code
-	assert.Equal(t, StatusCode, status.Code())
-
-	// Test ReqID
-	assert.Equal(t, uint64(0), status.ReqID())
-
-	// Test GetGenesis
-	assert.Equal(t, genesis[:], status.GetGenesis())
-
-	// Test GetHead
-	assert.Equal(t, head[:], status.GetHead())
-
-	// Test GetNetworkID
-	assert.Equal(t, uint64(1), status.GetNetworkID())
-
-	// Test GetForkIDHash
-	assert.Equal(t, forkIDHash[:], status.GetForkIDHash())
-
-	// Test GetForkIDNext
-	assert.Equal(t, uint64(1000), status.GetForkIDNext())
 }
 
 func TestStatus69Interface(t *testing.T) {
@@ -73,7 +26,7 @@ func TestStatus69Interface(t *testing.T) {
 	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
 
 	status := &Status69{
-		StatusPacket69: eth.StatusPacket69{
+		StatusPacket: eth.StatusPacket{
 			ProtocolVersion: 69,
 			NetworkID:       1,
 			Genesis:         genesis,
@@ -87,64 +40,15 @@ func TestStatus69Interface(t *testing.T) {
 		},
 	}
 
-	// Test interface compliance
 	var _ Status = status
 
-	// Test Code
 	assert.Equal(t, StatusCode, status.Code())
-
-	// Test ReqID
 	assert.Equal(t, uint64(0), status.ReqID())
-
-	// Test GetGenesis
 	assert.Equal(t, genesis[:], status.GetGenesis())
-
-	// Test GetHead - for Status69, this returns LatestBlockHash
 	assert.Equal(t, latestBlockHash[:], status.GetHead())
-
-	// Test GetNetworkID
 	assert.Equal(t, uint64(1), status.GetNetworkID())
-
-	// Test GetForkIDHash
 	assert.Equal(t, forkIDHash[:], status.GetForkIDHash())
-
-	// Test GetForkIDNext
 	assert.Equal(t, uint64(2000), status.GetForkIDNext())
-}
-
-func TestStatusRLPEncoding68(t *testing.T) {
-	genesis := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
-	head := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
-	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
-
-	original := eth.StatusPacket68{
-		ProtocolVersion: 68,
-		NetworkID:       1,
-		Head:            head,
-		Genesis:         genesis,
-		ForkID: forkid.ID{
-			Hash: forkIDHash,
-			Next: 1000,
-		},
-	}
-
-	// Encode
-	encoded, err := rlp.EncodeToBytes(&original)
-	require.NoError(t, err)
-	require.NotEmpty(t, encoded)
-
-	// Decode
-	var decoded eth.StatusPacket68
-	err = rlp.DecodeBytes(encoded, &decoded)
-	require.NoError(t, err)
-
-	// Verify
-	assert.Equal(t, original.ProtocolVersion, decoded.ProtocolVersion)
-	assert.Equal(t, original.NetworkID, decoded.NetworkID)
-	assert.Equal(t, original.Head, decoded.Head)
-	assert.Equal(t, original.Genesis, decoded.Genesis)
-	assert.Equal(t, original.ForkID.Hash, decoded.ForkID.Hash)
-	assert.Equal(t, original.ForkID.Next, decoded.ForkID.Next)
 }
 
 func TestStatusRLPEncoding69(t *testing.T) {
@@ -152,7 +56,7 @@ func TestStatusRLPEncoding69(t *testing.T) {
 	latestBlockHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
 	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
 
-	original := eth.StatusPacket69{
+	original := eth.StatusPacket{
 		ProtocolVersion: 69,
 		NetworkID:       1,
 		Genesis:         genesis,
@@ -165,17 +69,14 @@ func TestStatusRLPEncoding69(t *testing.T) {
 		LatestBlockHash: latestBlockHash,
 	}
 
-	// Encode
 	encoded, err := rlp.EncodeToBytes(&original)
 	require.NoError(t, err)
 	require.NotEmpty(t, encoded)
 
-	// Decode
-	var decoded eth.StatusPacket69
+	var decoded eth.StatusPacket
 	err = rlp.DecodeBytes(encoded, &decoded)
 	require.NoError(t, err)
 
-	// Verify
 	assert.Equal(t, original.ProtocolVersion, decoded.ProtocolVersion)
 	assert.Equal(t, original.NetworkID, decoded.NetworkID)
 	assert.Equal(t, original.Genesis, decoded.Genesis)
@@ -187,8 +88,6 @@ func TestStatusRLPEncoding69(t *testing.T) {
 }
 
 func TestStatusInterfaceCompliance(t *testing.T) {
-	// Ensure both Status68 and Status69 implement the Status interface
-	var _ Status = (*Status68)(nil)
 	var _ Status = (*Status69)(nil)
 }
 
@@ -205,15 +104,8 @@ func TestStatusDifferentNetworks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status68 := &Status68{
-				StatusPacket68: eth.StatusPacket68{
-					NetworkID: tt.networkID,
-				},
-			}
-			assert.Equal(t, tt.networkID, status68.GetNetworkID())
-
 			status69 := &Status69{
-				StatusPacket69: eth.StatusPacket69{
+				StatusPacket: eth.StatusPacket{
 					NetworkID: tt.networkID,
 				},
 			}

--- a/pkg/execution/mimicry/publish_test.go
+++ b/pkg/execution/mimicry/publish_test.go
@@ -136,9 +136,9 @@ func TestOnStatus(t *testing.T) {
 	})
 
 	// Publish a status event
-	expectedStatus := &Status68{
-		StatusPacket68: eth.StatusPacket68{
-			ProtocolVersion: 68,
+	expectedStatus := &Status69{
+		StatusPacket: eth.StatusPacket{
+			ProtocolVersion: 69,
 			NetworkID:       1,
 		},
 	}

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -255,7 +255,7 @@ func waitForGenesis(ctx context.Context, tf *TestFoundation, epgNetwork network.
 
 	// Start the beacon node with a background context
 	// We'll stop it manually when we're done
-	go func() {
+	go func() { //nolint:gosec // intentionally using background context; beacon node is stopped manually via defer
 		if err := tempBeacon.Start(context.Background()); err != nil {
 			tf.Logger.WithError(err).Warn("Temporary beacon node error during genesis check")
 		}

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -421,11 +421,13 @@ func cleanupNetwork(t *testing.T, config *NetworkConfig) error {
 
 // createParticipantConfig creates participant configuration based on NetworkConfig.
 func createParticipantConfig(config *NetworkConfig) []epgconfig.ParticipantConfig {
-	// Default participant configuration with diverse client types
+	// Default participant configuration with diverse client types.
+	// Note: Prysm v7+ post-Fulu only supports status/2, which the crawler
+	// doesn't yet implement. Use lodestar instead until status/2 is added.
 	participants := []epgconfig.ParticipantConfig{
 		{ELType: "geth", CLType: "lighthouse", Count: 2},
 		{ELType: "geth", CLType: "teku", Count: 1},
-		{ELType: "geth", CLType: "prysm", Count: 1},
+		{ELType: "geth", CLType: "lodestar", Count: 1},
 	}
 
 	// Adjust based on the number of participants requested

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -422,12 +422,12 @@ func cleanupNetwork(t *testing.T, config *NetworkConfig) error {
 // createParticipantConfig creates participant configuration based on NetworkConfig.
 func createParticipantConfig(config *NetworkConfig) []epgconfig.ParticipantConfig {
 	// Default participant configuration with diverse client types.
-	// Note: Prysm v7+ post-Fulu only supports status/2, which the crawler
-	// doesn't yet implement. Use lodestar instead until status/2 is added.
+	// Note: Post-Fulu, Prysm and Lodestar only support status/2 which
+	// the crawler doesn't yet implement. Use lighthouse and teku which
+	// still support status/1 until status/2 is added.
 	participants := []epgconfig.ParticipantConfig{
 		{ELType: "geth", CLType: "lighthouse", Count: 2},
-		{ELType: "geth", CLType: "teku", Count: 1},
-		{ELType: "geth", CLType: "lodestar", Count: 1},
+		{ELType: "geth", CLType: "teku", Count: 2},
 	}
 
 	// Adjust based on the number of participants requested

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -422,12 +422,11 @@ func cleanupNetwork(t *testing.T, config *NetworkConfig) error {
 // createParticipantConfig creates participant configuration based on NetworkConfig.
 func createParticipantConfig(config *NetworkConfig) []epgconfig.ParticipantConfig {
 	// Default participant configuration with diverse client types.
-	// Note: Post-Fulu, Prysm and Lodestar only support status/2 which
-	// the crawler doesn't yet implement. Use lighthouse and teku which
-	// still support status/1 until status/2 is added.
 	participants := []epgconfig.ParticipantConfig{
-		{ELType: "geth", CLType: "lighthouse", Count: 2},
-		{ELType: "geth", CLType: "teku", Count: 2},
+		{ELType: "geth", CLType: "lighthouse", Count: 1},
+		{ELType: "geth", CLType: "teku", Count: 1},
+		{ELType: "geth", CLType: "prysm", Count: 1},
+		{ELType: "geth", CLType: "lodestar", Count: 1},
 	}
 
 	// Adjust based on the number of participants requested


### PR DESCRIPTION
## Summary
- Bump go-ethereum from v1.17.0 to v1.17.1
- Remove eth/68 protocol support from mimicry (go-ethereum v1.17.1 dropped it)
- Update `StatusPacket68`/`StatusPacket69` to unified `StatusPacket`
- Update generic `ReceiptsPacket[T]` to non-generic `ReceiptsPacket`
- Update `ReceiptList68`/`ReceiptList69` and `NewReceiptList68`/`NewReceiptList69` to unified `ReceiptList`/`NewReceiptList`
- Set `minETHProtocolVersion` to 69, add min version check in `ETHProtocolVersion()`
- Update all tests to reflect eth/69-only support

## Test plan
- [x] All mimicry package tests pass
- [x] Full project builds successfully
- [ ] Verify P2P connectivity with eth/69 peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)