### PR TITLE
feat: add status/2 and metadata/3 protocol support for Fulu fork

### DIFF
--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/protolambda/ztyp/tree"
 	"github.com/sirupsen/logrus"
@@ -597,73 +598,151 @@ func (c *Crawler) DisconnectFromPeer(ctx context.Context, peerID peer.ID, reason
 	return c.node.DisconnectFromPeer(ctx, peerID)
 }
 
+// RequestStatusFromPeer requests the consensus status from a peer.
+// It tries status/2 (Fulu) first, falling back to status/1 if the peer
+// does not support it.
 func (c *Crawler) RequestStatusFromPeer(ctx context.Context, peerID peer.ID) (*common.Status, error) {
 	status := c.GetStatus()
+	statusV2 := eth.StatusV2FromV1(&status)
 
-	req := &p2p.Request{
+	// Try status/2 first.
+	rspV2 := &eth.StatusV2{}
+
+	err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.StatusV2ProtocolID,
+		PeerID:     peerID,
+		Payload:    statusV2,
+		Timeout:    time.Second * 30,
+	}, rspV2)
+	if err == nil {
+		result := rspV2.ToV1()
+		if status.ForkDigest != result.ForkDigest {
+			c.emitPeerStatusUpdated(&PeerStatusUpdated{
+				PeerID: peerID,
+				ENR:    c.GetPeerENR(peerID),
+				Status: result,
+			})
+		}
+
+		return result, nil
+	}
+
+	// Fall back to status/1 if the peer doesn't support status/2.
+	if !isStreamCreationError(err) {
+		c.recordRequestError(eth.StatusV2ProtocolID, err)
+
+		return nil, fmt.Errorf("failed to send status v2 request: %w", err)
+	}
+
+	c.log.WithField("peer", peerID).Debug("Peer does not support status/2, falling back to status/1")
+
+	rspV1 := &common.Status{}
+
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
 		ProtocolID: eth.StatusV1ProtocolID,
 		PeerID:     peerID,
 		Payload:    &status,
 		Timeout:    time.Second * 30,
+	}, rspV1); err != nil {
+		c.recordRequestError(eth.StatusV1ProtocolID, err)
+
+		return nil, fmt.Errorf("failed to send status v1 request: %w", err)
 	}
 
-	rsp := &common.Status{}
-
-	if err := c.reqResp.SendRequest(ctx, req, rsp); err != nil {
-		errType := &p2p.RequestError{}
-
-		if errors.As(err, &errType) {
-			c.metrics.RecordFailedRequest(string(req.ProtocolID), errType.Type)
-
-			return nil, fmt.Errorf("failed to send request: %w", err)
-		}
-
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	if status.ForkDigest != rsp.ForkDigest {
+	if status.ForkDigest != rspV1.ForkDigest {
 		c.emitPeerStatusUpdated(&PeerStatusUpdated{
 			PeerID: peerID,
 			ENR:    c.GetPeerENR(peerID),
-			Status: rsp,
+			Status: rspV1,
 		})
 	}
 
-	return rsp, nil
+	return rspV1, nil
 }
 
+// RequestMetadataFromPeer requests metadata from a peer.
+// It tries metadata/3 (Fulu) first, falling back to metadata/2.
 func (c *Crawler) RequestMetadataFromPeer(ctx context.Context, peerID peer.ID) (*common.MetaData, error) {
 	c.log.WithField("peer", peerID.String()).Debug("Requesting metadata from peer")
 
-	// NOTE: Per the Ethereum consensus spec, metadata requests have NO payload.
-	// We must send nil as the payload to comply with the specification.
-	// See: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#getmetadata-v1
-	req := &p2p.Request{
-		ProtocolID: eth.MetaDataV2ProtocolID,
+	// Try metadata/3 first (no payload per spec).
+	rspV3 := &eth.MetaDataV3{}
+
+	err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.MetaDataV3ProtocolID,
 		PeerID:     peerID,
-		Payload:    nil, // Metadata requests have no payload per spec
+		Payload:    nil,
 		Timeout:    time.Second * 30,
+	}, rspV3)
+	if err == nil {
+		result := rspV3.ToV2()
+
+		c.log.WithFields(logrus.Fields{
+			"peer":                peerID.String(),
+			"seq_number":          result.SeqNumber,
+			"attnets":             fmt.Sprintf("%x", result.Attnets),
+			"custody_group_count": rspV3.CustodyGroupCount,
+		}).Debug("Successfully received metadata v3")
+
+		c.emitMetadataReceived(&MetadataReceived{
+			PeerID:   peerID,
+			ENR:      c.GetPeerENR(peerID),
+			Metadata: result,
+		})
+
+		return result, nil
 	}
 
-	rsp := &common.MetaData{}
+	// Fall back to metadata/2 if the peer doesn't support metadata/3.
+	if !isStreamCreationError(err) {
+		return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
+	}
 
-	if err := c.reqResp.SendRequest(ctx, req, rsp); err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+	c.log.WithField("peer", peerID).Debug("Peer does not support metadata/3, falling back to metadata/2")
+
+	rspV2 := &common.MetaData{}
+
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: eth.MetaDataV2ProtocolID,
+		PeerID:     peerID,
+		Payload:    nil,
+		Timeout:    time.Second * 30,
+	}, rspV2); err != nil {
+		return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
 	}
 
 	c.log.WithFields(logrus.Fields{
 		"peer":       peerID.String(),
-		"seq_number": rsp.SeqNumber,
-		"attnets":    fmt.Sprintf("%x", rsp.Attnets),
-	}).Debug("Successfully received metadata")
+		"seq_number": rspV2.SeqNumber,
+		"attnets":    fmt.Sprintf("%x", rspV2.Attnets),
+	}).Debug("Successfully received metadata v2")
 
 	c.emitMetadataReceived(&MetadataReceived{
 		PeerID:   peerID,
 		ENR:      c.GetPeerENR(peerID),
-		Metadata: rsp,
+		Metadata: rspV2,
 	})
 
-	return rsp, nil
+	return rspV2, nil
+}
+
+// isStreamCreationError returns true if the error is a protocol negotiation
+// failure (peer doesn't support the requested protocol version).
+func isStreamCreationError(err error) bool {
+	var reqErr *p2p.RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.Type == p2p.ErrFailedToCreateStream.Type
+	}
+
+	return false
+}
+
+// recordRequestError records a failed request metric if the error is a RequestError.
+func (c *Crawler) recordRequestError(protocolID protocol.ID, err error) {
+	var reqErr *p2p.RequestError
+	if errors.As(err, &reqErr) {
+		c.metrics.RecordFailedRequest(string(protocolID), reqErr.Type)
+	}
 }
 
 func (c *Crawler) GetPeerAgentVersion(peerID peer.ID) string {

--- a/pkg/consensus/mimicry/crawler/crawler.go
+++ b/pkg/consensus/mimicry/crawler/crawler.go
@@ -599,150 +599,116 @@ func (c *Crawler) DisconnectFromPeer(ctx context.Context, peerID peer.ID, reason
 }
 
 // RequestStatusFromPeer requests the consensus status from a peer.
-// It tries status/2 (Fulu) first, falling back to status/1 if the peer
-// does not support it.
+// It picks status/2 or status/1 based on the peer's advertised protocols.
 func (c *Crawler) RequestStatusFromPeer(ctx context.Context, peerID peer.ID) (*common.Status, error) {
 	status := c.GetStatus()
-	statusV2 := eth.StatusV2FromV1(&status)
 
-	// Try status/2 first.
-	rspV2 := &eth.StatusV2{}
+	proto, err := c.node.Peerstore().FirstSupportedProtocol(peerID, eth.StatusV2ProtocolID, eth.StatusV1ProtocolID)
+	if err != nil || proto == "" {
+		proto = eth.StatusV1ProtocolID // default to v1 if protocol info unavailable
+	}
 
-	err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.StatusV2ProtocolID,
-		PeerID:     peerID,
-		Payload:    statusV2,
-		Timeout:    time.Second * 30,
-	}, rspV2)
-	if err == nil {
-		result := rspV2.ToV1()
-		if status.ForkDigest != result.ForkDigest {
-			c.emitPeerStatusUpdated(&PeerStatusUpdated{
-				PeerID: peerID,
-				ENR:    c.GetPeerENR(peerID),
-				Status: result,
-			})
+	var result *common.Status
+
+	if proto == eth.StatusV2ProtocolID {
+		statusV2 := eth.StatusV2FromV1(&status)
+		rsp := &eth.StatusV2{}
+
+		if err := c.sendRequest(ctx, proto, peerID, statusV2, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send status v2 request: %w", err)
 		}
 
-		return result, nil
+		result = rsp.ToV1()
+	} else {
+		rsp := &common.Status{}
+
+		if err := c.sendRequest(ctx, proto, peerID, &status, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send status v1 request: %w", err)
+		}
+
+		result = rsp
 	}
 
-	// Fall back to status/1 if the peer doesn't support status/2.
-	if !isStreamCreationError(err) {
-		c.recordRequestError(eth.StatusV2ProtocolID, err)
-
-		return nil, fmt.Errorf("failed to send status v2 request: %w", err)
-	}
-
-	c.log.WithField("peer", peerID).Debug("Peer does not support status/2, falling back to status/1")
-
-	rspV1 := &common.Status{}
-
-	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.StatusV1ProtocolID,
-		PeerID:     peerID,
-		Payload:    &status,
-		Timeout:    time.Second * 30,
-	}, rspV1); err != nil {
-		c.recordRequestError(eth.StatusV1ProtocolID, err)
-
-		return nil, fmt.Errorf("failed to send status v1 request: %w", err)
-	}
-
-	if status.ForkDigest != rspV1.ForkDigest {
+	if status.ForkDigest != result.ForkDigest {
 		c.emitPeerStatusUpdated(&PeerStatusUpdated{
 			PeerID: peerID,
 			ENR:    c.GetPeerENR(peerID),
-			Status: rspV1,
+			Status: result,
 		})
 	}
 
-	return rspV1, nil
+	return result, nil
 }
 
 // RequestMetadataFromPeer requests metadata from a peer.
-// It tries metadata/3 (Fulu) first, falling back to metadata/2.
+// It picks metadata/3 or metadata/2 based on the peer's advertised protocols.
 func (c *Crawler) RequestMetadataFromPeer(ctx context.Context, peerID peer.ID) (*common.MetaData, error) {
 	c.log.WithField("peer", peerID.String()).Debug("Requesting metadata from peer")
 
-	// Try metadata/3 first (no payload per spec).
-	rspV3 := &eth.MetaDataV3{}
+	proto, err := c.node.Peerstore().FirstSupportedProtocol(peerID, eth.MetaDataV3ProtocolID, eth.MetaDataV2ProtocolID)
+	if err != nil || proto == "" {
+		proto = eth.MetaDataV2ProtocolID // default to v2 if protocol info unavailable
+	}
 
-	err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.MetaDataV3ProtocolID,
-		PeerID:     peerID,
-		Payload:    nil,
-		Timeout:    time.Second * 30,
-	}, rspV3)
-	if err == nil {
-		result := rspV3.ToV2()
+	var result *common.MetaData
+
+	if proto == eth.MetaDataV3ProtocolID {
+		rsp := &eth.MetaDataV3{}
+
+		if err := c.sendRequest(ctx, proto, peerID, nil, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
+		}
+
+		result = rsp.ToV2()
 
 		c.log.WithFields(logrus.Fields{
 			"peer":                peerID.String(),
 			"seq_number":          result.SeqNumber,
 			"attnets":             fmt.Sprintf("%x", result.Attnets),
-			"custody_group_count": rspV3.CustodyGroupCount,
+			"custody_group_count": rsp.CustodyGroupCount,
 		}).Debug("Successfully received metadata v3")
+	} else {
+		rsp := &common.MetaData{}
 
-		c.emitMetadataReceived(&MetadataReceived{
-			PeerID:   peerID,
-			ENR:      c.GetPeerENR(peerID),
-			Metadata: result,
-		})
+		if err := c.sendRequest(ctx, proto, peerID, nil, rsp); err != nil {
+			return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
+		}
 
-		return result, nil
+		result = rsp
+
+		c.log.WithFields(logrus.Fields{
+			"peer":       peerID.String(),
+			"seq_number": result.SeqNumber,
+			"attnets":    fmt.Sprintf("%x", result.Attnets),
+		}).Debug("Successfully received metadata v2")
 	}
-
-	// Fall back to metadata/2 if the peer doesn't support metadata/3.
-	if !isStreamCreationError(err) {
-		return nil, fmt.Errorf("failed to send metadata v3 request: %w", err)
-	}
-
-	c.log.WithField("peer", peerID).Debug("Peer does not support metadata/3, falling back to metadata/2")
-
-	rspV2 := &common.MetaData{}
-
-	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
-		ProtocolID: eth.MetaDataV2ProtocolID,
-		PeerID:     peerID,
-		Payload:    nil,
-		Timeout:    time.Second * 30,
-	}, rspV2); err != nil {
-		return nil, fmt.Errorf("failed to send metadata v2 request: %w", err)
-	}
-
-	c.log.WithFields(logrus.Fields{
-		"peer":       peerID.String(),
-		"seq_number": rspV2.SeqNumber,
-		"attnets":    fmt.Sprintf("%x", rspV2.Attnets),
-	}).Debug("Successfully received metadata v2")
 
 	c.emitMetadataReceived(&MetadataReceived{
 		PeerID:   peerID,
 		ENR:      c.GetPeerENR(peerID),
-		Metadata: rspV2,
+		Metadata: result,
 	})
 
-	return rspV2, nil
+	return result, nil
 }
 
-// isStreamCreationError returns true if the error is a protocol negotiation
-// failure (peer doesn't support the requested protocol version).
-func isStreamCreationError(err error) bool {
-	var reqErr *p2p.RequestError
-	if errors.As(err, &reqErr) {
-		return reqErr.Type == p2p.ErrFailedToCreateStream.Type
+// sendRequest sends a request on the given protocol and records metrics on failure.
+func (c *Crawler) sendRequest(ctx context.Context, proto protocol.ID, peerID peer.ID, payload, rsp common.SSZObj) error {
+	if err := c.reqResp.SendRequest(ctx, &p2p.Request{
+		ProtocolID: proto,
+		PeerID:     peerID,
+		Payload:    payload,
+		Timeout:    time.Second * 30,
+	}, rsp); err != nil {
+		var reqErr *p2p.RequestError
+		if errors.As(err, &reqErr) {
+			c.metrics.RecordFailedRequest(string(proto), reqErr.Type)
+		}
+
+		return err
 	}
 
-	return false
-}
-
-// recordRequestError records a failed request metric if the error is a RequestError.
-func (c *Crawler) recordRequestError(protocolID protocol.ID, err error) {
-	var reqErr *p2p.RequestError
-	if errors.As(err, &reqErr) {
-		c.metrics.RecordFailedRequest(string(protocolID), reqErr.Type)
-	}
+	return nil
 }
 
 func (c *Crawler) GetPeerAgentVersion(peerID peer.ID) string {

--- a/pkg/consensus/mimicry/crawler/req_handlers.go
+++ b/pkg/consensus/mimicry/crawler/req_handlers.go
@@ -82,23 +82,22 @@ func (c *Crawler) readIncomingStatus(
 	stream network.Stream,
 	logCtx *logrus.Entry,
 ) (*common.Status, error) {
+	var (
+		payload common.SSZObj
+		toV1    func() *common.Status
+	)
+
 	if stream.Protocol() == eth.StatusV2ProtocolID {
-		var v2 eth.StatusV2
-		if err := c.reqResp.ReadRequest(ctx, stream, &v2); err != nil {
-			logCtx.WithError(err).Error("Failed to decode status v2 message")
-
-			if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
-				logCtx.WithError(errr).Debug("Failed to send error response")
-			}
-
-			return nil, err
-		}
-
-		return v2.ToV1(), nil
+		v2 := &eth.StatusV2{}
+		payload = v2
+		toV1 = v2.ToV1
+	} else {
+		v1 := &common.Status{}
+		payload = v1
+		toV1 = func() *common.Status { return v1 }
 	}
 
-	var v1 common.Status
-	if err := c.reqResp.ReadRequest(ctx, stream, &v1); err != nil {
+	if err := c.reqResp.ReadRequest(ctx, stream, payload); err != nil {
 		logCtx.WithError(err).Error("Failed to decode status message")
 
 		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
@@ -108,7 +107,7 @@ func (c *Crawler) readIncomingStatus(
 		return nil, err
 	}
 
-	return &v1, nil
+	return toV1(), nil
 }
 
 // writeStatusResponse writes our status in the protocol version the peer used.
@@ -118,18 +117,13 @@ func (c *Crawler) writeStatusResponse(
 	status *common.Status,
 	logCtx *logrus.Entry,
 ) error {
+	var payload common.SSZObj = status
+
 	if stream.Protocol() == eth.StatusV2ProtocolID {
-		v2 := eth.StatusV2FromV1(status)
-		if err := c.reqResp.WriteResponse(ctx, stream, v2, nil); err != nil {
-			logCtx.WithError(err).Debug("Failed to send status v2 response")
-
-			return err
-		}
-
-		return nil
+		payload = eth.StatusV2FromV1(status)
 	}
 
-	if err := c.reqResp.WriteResponse(ctx, stream, status, nil); err != nil {
+	if err := c.reqResp.WriteResponse(ctx, stream, payload, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send status response")
 
 		return err
@@ -263,7 +257,6 @@ func (c *Crawler) handleMetadata(ctx context.Context, stream network.Stream) err
 
 	if stream.Protocol() == eth.MetaDataV3ProtocolID {
 		v3 := eth.MetaDataV3FromV2(c.metadata)
-		v3.CustodyGroupCount = eth.DefaultCustodyGroupCount
 
 		if err := c.reqResp.WriteResponse(ctx, stream, v3, nil); err != nil {
 			logCtx.WithError(err).Debug("Failed to send metadata v3 response")

--- a/pkg/consensus/mimicry/crawler/req_handlers.go
+++ b/pkg/consensus/mimicry/crawler/req_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/sirupsen/logrus"
@@ -28,16 +29,9 @@ func (c *Crawler) handleStatus(ctx context.Context, stream network.Stream) error
 		}
 	}()
 
-	var theirStatus common.Status
-
-	err := c.reqResp.ReadRequest(ctx, stream, &theirStatus)
+	// Decode the incoming status based on the negotiated protocol version.
+	theirStatus, err := c.readIncomingStatus(ctx, stream, logCtx)
 	if err != nil {
-		logCtx.WithError(err).Error("Failed to decode status message")
-
-		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
-			logCtx.WithError(errr).Debug("Failed to send status response in response to decode error")
-		}
-
 		return err
 	}
 
@@ -74,7 +68,68 @@ func (c *Crawler) handleStatus(ctx context.Context, stream network.Stream) error
 		})
 	}
 
-	if err := c.reqResp.WriteResponse(ctx, stream, &status, nil); err != nil {
+	// Respond with our status in the same protocol version the peer used.
+	if err := c.writeStatusResponse(ctx, stream, &status, logCtx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readIncomingStatus decodes a status request from the stream, handling both v1 and v2.
+func (c *Crawler) readIncomingStatus(
+	ctx context.Context,
+	stream network.Stream,
+	logCtx *logrus.Entry,
+) (*common.Status, error) {
+	if stream.Protocol() == eth.StatusV2ProtocolID {
+		var v2 eth.StatusV2
+		if err := c.reqResp.ReadRequest(ctx, stream, &v2); err != nil {
+			logCtx.WithError(err).Error("Failed to decode status v2 message")
+
+			if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
+				logCtx.WithError(errr).Debug("Failed to send error response")
+			}
+
+			return nil, err
+		}
+
+		return v2.ToV1(), nil
+	}
+
+	var v1 common.Status
+	if err := c.reqResp.ReadRequest(ctx, stream, &v1); err != nil {
+		logCtx.WithError(err).Error("Failed to decode status message")
+
+		if errr := c.reqResp.WriteResponse(ctx, stream, nil, errors.New("failed to decode request body")); errr != nil {
+			logCtx.WithError(errr).Debug("Failed to send error response")
+		}
+
+		return nil, err
+	}
+
+	return &v1, nil
+}
+
+// writeStatusResponse writes our status in the protocol version the peer used.
+func (c *Crawler) writeStatusResponse(
+	ctx context.Context,
+	stream network.Stream,
+	status *common.Status,
+	logCtx *logrus.Entry,
+) error {
+	if stream.Protocol() == eth.StatusV2ProtocolID {
+		v2 := eth.StatusV2FromV1(status)
+		if err := c.reqResp.WriteResponse(ctx, stream, v2, nil); err != nil {
+			logCtx.WithError(err).Debug("Failed to send status v2 response")
+
+			return err
+		}
+
+		return nil
+	}
+
+	if err := c.reqResp.WriteResponse(ctx, stream, status, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send status response")
 
 		return err
@@ -202,14 +257,24 @@ func (c *Crawler) handleMetadata(ctx context.Context, stream network.Stream) err
 		}
 	}()
 
-	// Metadata requests have no content per the Ethereum consensus spec
-	// The request opens and negotiates the stream without sending any request content
-	// We immediately respond with our local metadata
+	// Metadata requests have no content per the Ethereum consensus spec.
+	// Respond with the appropriate version based on the negotiated protocol.
 	logCtx.Debug("Received metadata request")
 
-	resp := c.metadata
+	if stream.Protocol() == eth.MetaDataV3ProtocolID {
+		v3 := eth.MetaDataV3FromV2(c.metadata)
+		v3.CustodyGroupCount = eth.DefaultCustodyGroupCount
 
-	if err := c.reqResp.WriteResponse(ctx, stream, resp, nil); err != nil {
+		if err := c.reqResp.WriteResponse(ctx, stream, v3, nil); err != nil {
+			logCtx.WithError(err).Debug("Failed to send metadata v3 response")
+
+			return err
+		}
+
+		return nil
+	}
+
+	if err := c.reqResp.WriteResponse(ctx, stream, c.metadata, nil); err != nil {
 		logCtx.WithError(err).Debug("Failed to send metadata response")
 
 		return err

--- a/pkg/consensus/mimicry/crawler/wiring.go
+++ b/pkg/consensus/mimicry/crawler/wiring.go
@@ -43,7 +43,11 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 
 	// Wire up the req/resp
 	if err := c.reqResp.RegisterHandler(ctx, eth.StatusV1ProtocolID, c.handleStatus); err != nil {
-		return fmt.Errorf("failed to register status handler: %w", err)
+		return fmt.Errorf("failed to register status v1 handler: %w", err)
+	}
+
+	if err := c.reqResp.RegisterHandler(ctx, eth.StatusV2ProtocolID, c.handleStatus); err != nil {
+		return fmt.Errorf("failed to register status v2 handler: %w", err)
 	}
 
 	if err := c.reqResp.RegisterHandler(ctx, eth.GoodbyeV1ProtocolID, c.handleGoodbye); err != nil {
@@ -55,7 +59,11 @@ func (c *Crawler) wireUpComponents(ctx context.Context) error {
 	}
 
 	if err := c.reqResp.RegisterHandler(ctx, eth.MetaDataV2ProtocolID, c.handleMetadata); err != nil {
-		return fmt.Errorf("failed to register metadata handler: %w", err)
+		return fmt.Errorf("failed to register metadata v2 handler: %w", err)
+	}
+
+	if err := c.reqResp.RegisterHandler(ctx, eth.MetaDataV3ProtocolID, c.handleMetadata); err != nil {
+		return fmt.Errorf("failed to register metadata v3 handler: %w", err)
 	}
 
 	// Register dummy RPC handlers for the ones we don't implement yet

--- a/pkg/consensus/mimicry/p2p/eth/metadata.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata.go
@@ -90,12 +90,13 @@ func (m *MetaDataV3) ToV2() *common.MetaData {
 	}
 }
 
-// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3, defaulting CustodyGroupCount to 0.
+// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3,
+// defaulting CustodyGroupCount to DefaultCustodyGroupCount.
 func MetaDataV3FromV2(m *common.MetaData) *MetaDataV3 {
 	return &MetaDataV3{
 		SeqNumber:         m.SeqNumber,
 		Attnets:           m.Attnets,
 		Syncnets:          m.Syncnets,
-		CustodyGroupCount: CustodyGroupCount(0),
+		CustodyGroupCount: DefaultCustodyGroupCount,
 	}
 }

--- a/pkg/consensus/mimicry/p2p/eth/metadata.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata.go
@@ -1,0 +1,101 @@
+package eth
+
+import (
+	"fmt"
+
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/tree"
+	"github.com/protolambda/ztyp/view"
+)
+
+// CustodyGroupCount represents the number of data column custody groups a node participates in.
+type CustodyGroupCount view.Uint64View
+
+// Deserialize implements codec.Deserializable.
+func (c *CustodyGroupCount) Deserialize(dr *codec.DecodingReader) error {
+	return (*view.Uint64View)(c).Deserialize(dr)
+}
+
+// Serialize implements codec.Serializable.
+func (c CustodyGroupCount) Serialize(w *codec.EncodingWriter) error {
+	return w.WriteUint64(uint64(c))
+}
+
+// ByteLength returns the SSZ byte length.
+func (CustodyGroupCount) ByteLength() uint64 { return 8 }
+
+// FixedLength returns the fixed SSZ byte length.
+func (CustodyGroupCount) FixedLength() uint64 { return 8 }
+
+// HashTreeRoot computes the SSZ hash tree root.
+func (c CustodyGroupCount) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return view.Uint64View(c).HashTreeRoot(hFn)
+}
+
+// DefaultCustodyGroupCount is the Fulu spec default for CUSTODY_REQUIREMENT.
+const DefaultCustodyGroupCount CustodyGroupCount = 4
+
+// MetaDataV3 is the Fulu (EIP-7594) version of the eth2 metadata message.
+// It extends MetaData with CustodyGroupCount for PeerDAS.
+type MetaDataV3 struct {
+	SeqNumber         common.SeqNr       `json:"seqNumber" yaml:"seqNumber"`
+	Attnets           common.AttnetBits  `json:"attnets" yaml:"attnets"`
+	Syncnets          common.SyncnetBits `json:"syncnets" yaml:"syncnets"`
+	CustodyGroupCount CustodyGroupCount  `json:"custodyGroupCount" yaml:"custodyGroupCount"`
+}
+
+// MetaDataV3ByteLen is the fixed SSZ byte length of MetaDataV3 (8+8+1+8 = 25).
+const MetaDataV3ByteLen = 8 + 8 + 1 + 8
+
+// Deserialize implements codec.Deserializable.
+func (m *MetaDataV3) Deserialize(dr *codec.DecodingReader) error {
+	return dr.FixedLenContainer(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// Serialize implements codec.Serializable.
+func (m *MetaDataV3) Serialize(w *codec.EncodingWriter) error {
+	return w.FixedLenContainer(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// ByteLength returns the SSZ byte length of MetaDataV3.
+func (m MetaDataV3) ByteLength() uint64 {
+	return MetaDataV3ByteLen
+}
+
+// FixedLength returns the fixed SSZ byte length of MetaDataV3.
+func (*MetaDataV3) FixedLength() uint64 {
+	return MetaDataV3ByteLen
+}
+
+// HashTreeRoot computes the SSZ hash tree root of MetaDataV3.
+func (m *MetaDataV3) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return hFn.HashTreeRoot(&m.SeqNumber, &m.Attnets, &m.Syncnets, &m.CustodyGroupCount)
+}
+
+// String returns a human-readable representation of MetaDataV3.
+func (m *MetaDataV3) String() string {
+	return fmt.Sprintf(
+		"MetaDataV3(seq: %d, attnet bits: %08b, syncnet bits: %08b, custody_group_count: %d)",
+		m.SeqNumber, m.Attnets, m.Syncnets, m.CustodyGroupCount,
+	)
+}
+
+// ToV2 converts a MetaDataV3 to a common.MetaData by dropping CustodyGroupCount.
+func (m *MetaDataV3) ToV2() *common.MetaData {
+	return &common.MetaData{
+		SeqNumber: m.SeqNumber,
+		Attnets:   m.Attnets,
+		Syncnets:  m.Syncnets,
+	}
+}
+
+// MetaDataV3FromV2 converts a common.MetaData to a MetaDataV3, defaulting CustodyGroupCount to 0.
+func MetaDataV3FromV2(m *common.MetaData) *MetaDataV3 {
+	return &MetaDataV3{
+		SeqNumber:         m.SeqNumber,
+		Attnets:           m.Attnets,
+		Syncnets:          m.Syncnets,
+		CustodyGroupCount: CustodyGroupCount(0),
+	}
+}

--- a/pkg/consensus/mimicry/p2p/eth/metadata_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata_test.go
@@ -69,7 +69,7 @@ func TestMetaDataV3FromV2(t *testing.T) {
 	assert.Equal(t, v2.SeqNumber, v3.SeqNumber)
 	assert.Equal(t, v2.Attnets, v3.Attnets)
 	assert.Equal(t, v2.Syncnets, v3.Syncnets)
-	assert.Equal(t, eth.CustodyGroupCount(0), v3.CustodyGroupCount)
+	assert.Equal(t, eth.DefaultCustodyGroupCount, v3.CustodyGroupCount)
 }
 
 func TestMetaDataV3_RoundTrip(t *testing.T) {

--- a/pkg/consensus/mimicry/p2p/eth/metadata_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/metadata_test.go
@@ -1,0 +1,87 @@
+package eth_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaDataV3_ByteLength(t *testing.T) {
+	m := &eth.MetaDataV3{}
+	assert.Equal(t, uint64(25), m.ByteLength())
+	assert.Equal(t, uint64(25), m.FixedLength())
+}
+
+func TestMetaDataV3_SerializeDeserialize(t *testing.T) {
+	original := &eth.MetaDataV3{
+		SeqNumber:         7,
+		Attnets:           common.AttnetBits{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00},
+		Syncnets:          common.SyncnetBits{0x0f},
+		CustodyGroupCount: 4,
+	}
+
+	// Serialize
+	var buf bytes.Buffer
+	err := original.Serialize(codec.NewEncodingWriter(&buf))
+	require.NoError(t, err)
+	assert.Equal(t, 25, buf.Len())
+
+	// Deserialize
+	decoded := &eth.MetaDataV3{}
+	err = decoded.Deserialize(codec.NewDecodingReader(bytes.NewReader(buf.Bytes()), uint64(buf.Len())))
+	require.NoError(t, err)
+
+	assert.Equal(t, original.SeqNumber, decoded.SeqNumber)
+	assert.Equal(t, original.Attnets, decoded.Attnets)
+	assert.Equal(t, original.Syncnets, decoded.Syncnets)
+	assert.Equal(t, original.CustodyGroupCount, decoded.CustodyGroupCount)
+}
+
+func TestMetaDataV3_ToV2(t *testing.T) {
+	v3 := &eth.MetaDataV3{
+		SeqNumber:         7,
+		Attnets:           common.AttnetBits{0xff},
+		Syncnets:          common.SyncnetBits{0x0f},
+		CustodyGroupCount: 4,
+	}
+
+	v2 := v3.ToV2()
+
+	assert.Equal(t, v3.SeqNumber, v2.SeqNumber)
+	assert.Equal(t, v3.Attnets, v2.Attnets)
+	assert.Equal(t, v3.Syncnets, v2.Syncnets)
+}
+
+func TestMetaDataV3FromV2(t *testing.T) {
+	v2 := &common.MetaData{
+		SeqNumber: 7,
+		Attnets:   common.AttnetBits{0xff},
+		Syncnets:  common.SyncnetBits{0x0f},
+	}
+
+	v3 := eth.MetaDataV3FromV2(v2)
+
+	assert.Equal(t, v2.SeqNumber, v3.SeqNumber)
+	assert.Equal(t, v2.Attnets, v3.Attnets)
+	assert.Equal(t, v2.Syncnets, v3.Syncnets)
+	assert.Equal(t, eth.CustodyGroupCount(0), v3.CustodyGroupCount)
+}
+
+func TestMetaDataV3_RoundTrip(t *testing.T) {
+	original := &common.MetaData{
+		SeqNumber: 42,
+		Attnets:   common.AttnetBits{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+		Syncnets:  common.SyncnetBits{0x0a},
+	}
+
+	// V2 -> V3 -> V2 should preserve all shared fields.
+	v3 := eth.MetaDataV3FromV2(original)
+	result := v3.ToV2()
+
+	assert.Equal(t, original, result)
+}

--- a/pkg/consensus/mimicry/p2p/eth/status.go
+++ b/pkg/consensus/mimicry/p2p/eth/status.go
@@ -1,11 +1,95 @@
 package eth
 
 import (
+	"fmt"
+
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/tree"
 )
 
+// PeerStatus associates a peer ID with its consensus status.
 type PeerStatus struct {
 	PeerID peer.ID
 	Status *common.Status
+}
+
+// StatusV2 is the Fulu (EIP-7594) version of the eth2 status message.
+// It extends Status with EarliestAvailableSlot for data availability advertisement.
+type StatusV2 struct {
+	ForkDigest            common.ForkDigest `json:"forkDigest" yaml:"forkDigest"`
+	FinalizedRoot         common.Root       `json:"finalizedRoot" yaml:"finalizedRoot"`
+	FinalizedEpoch        common.Epoch      `json:"finalizedEpoch" yaml:"finalizedEpoch"`
+	HeadRoot              common.Root       `json:"headRoot" yaml:"headRoot"`
+	HeadSlot              common.Slot       `json:"headSlot" yaml:"headSlot"`
+	EarliestAvailableSlot common.Slot       `json:"earliestAvailableSlot" yaml:"earliestAvailableSlot"`
+}
+
+// StatusV2ByteLen is the fixed SSZ byte length of StatusV2 (4+32+8+32+8+8 = 92).
+const StatusV2ByteLen = 4 + 32 + 8 + 32 + 8 + 8
+
+// Deserialize implements codec.Deserializable.
+func (s *StatusV2) Deserialize(dr *codec.DecodingReader) error {
+	return dr.FixedLenContainer(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// Serialize implements codec.Serializable.
+func (s *StatusV2) Serialize(w *codec.EncodingWriter) error {
+	return w.FixedLenContainer(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// ByteLength returns the SSZ byte length of StatusV2.
+func (s StatusV2) ByteLength() uint64 {
+	return StatusV2ByteLen
+}
+
+// FixedLength returns the fixed SSZ byte length of StatusV2.
+func (*StatusV2) FixedLength() uint64 {
+	return StatusV2ByteLen
+}
+
+// HashTreeRoot computes the SSZ hash tree root of StatusV2.
+func (s *StatusV2) HashTreeRoot(hFn tree.HashFn) common.Root {
+	return hFn.HashTreeRoot(
+		&s.ForkDigest, &s.FinalizedRoot, &s.FinalizedEpoch,
+		&s.HeadRoot, &s.HeadSlot, &s.EarliestAvailableSlot,
+	)
+}
+
+// String returns a human-readable representation of StatusV2.
+func (s *StatusV2) String() string {
+	return fmt.Sprintf(
+		"StatusV2(fork_digest: %s, finalized_root: %s, finalized_epoch: %d, head_root: %s, head_slot: %d, earliest_available_slot: %d)",
+		s.ForkDigest.String(), s.FinalizedRoot.String(), s.FinalizedEpoch, s.HeadRoot.String(), s.HeadSlot, s.EarliestAvailableSlot,
+	)
+}
+
+// ToV1 converts a StatusV2 to a common.Status by dropping EarliestAvailableSlot.
+func (s *StatusV2) ToV1() *common.Status {
+	return &common.Status{
+		ForkDigest:     s.ForkDigest,
+		FinalizedRoot:  s.FinalizedRoot,
+		FinalizedEpoch: s.FinalizedEpoch,
+		HeadRoot:       s.HeadRoot,
+		HeadSlot:       s.HeadSlot,
+	}
+}
+
+// StatusV2FromV1 converts a common.Status to a StatusV2, defaulting EarliestAvailableSlot to 0.
+func StatusV2FromV1(s *common.Status) *StatusV2 {
+	return &StatusV2{
+		ForkDigest:            s.ForkDigest,
+		FinalizedRoot:         s.FinalizedRoot,
+		FinalizedEpoch:        s.FinalizedEpoch,
+		HeadRoot:              s.HeadRoot,
+		HeadSlot:              s.HeadSlot,
+		EarliestAvailableSlot: 0,
+	}
 }

--- a/pkg/consensus/mimicry/p2p/eth/status_test.go
+++ b/pkg/consensus/mimicry/p2p/eth/status_test.go
@@ -1,0 +1,101 @@
+package eth_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethpandaops/ethcore/pkg/consensus/mimicry/p2p/eth"
+	"github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusV2_ByteLength(t *testing.T) {
+	s := &eth.StatusV2{}
+	assert.Equal(t, uint64(92), s.ByteLength())
+	assert.Equal(t, uint64(92), s.FixedLength())
+}
+
+func TestStatusV2_SerializeDeserialize(t *testing.T) {
+	original := &eth.StatusV2{
+		ForkDigest:            common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:         common.Root{0xaa},
+		FinalizedEpoch:        42,
+		HeadRoot:              common.Root{0xbb},
+		HeadSlot:              100,
+		EarliestAvailableSlot: 50,
+	}
+
+	// Serialize
+	var buf bytes.Buffer
+	err := original.Serialize(codec.NewEncodingWriter(&buf))
+	require.NoError(t, err)
+	assert.Equal(t, 92, buf.Len())
+
+	// Deserialize
+	decoded := &eth.StatusV2{}
+	err = decoded.Deserialize(codec.NewDecodingReader(bytes.NewReader(buf.Bytes()), uint64(buf.Len())))
+	require.NoError(t, err)
+
+	assert.Equal(t, original.ForkDigest, decoded.ForkDigest)
+	assert.Equal(t, original.FinalizedRoot, decoded.FinalizedRoot)
+	assert.Equal(t, original.FinalizedEpoch, decoded.FinalizedEpoch)
+	assert.Equal(t, original.HeadRoot, decoded.HeadRoot)
+	assert.Equal(t, original.HeadSlot, decoded.HeadSlot)
+	assert.Equal(t, original.EarliestAvailableSlot, decoded.EarliestAvailableSlot)
+}
+
+func TestStatusV2_ToV1(t *testing.T) {
+	v2 := &eth.StatusV2{
+		ForkDigest:            common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:         common.Root{0xaa},
+		FinalizedEpoch:        42,
+		HeadRoot:              common.Root{0xbb},
+		HeadSlot:              100,
+		EarliestAvailableSlot: 50,
+	}
+
+	v1 := v2.ToV1()
+
+	assert.Equal(t, v2.ForkDigest, v1.ForkDigest)
+	assert.Equal(t, v2.FinalizedRoot, v1.FinalizedRoot)
+	assert.Equal(t, v2.FinalizedEpoch, v1.FinalizedEpoch)
+	assert.Equal(t, v2.HeadRoot, v1.HeadRoot)
+	assert.Equal(t, v2.HeadSlot, v1.HeadSlot)
+}
+
+func TestStatusV2FromV1(t *testing.T) {
+	v1 := &common.Status{
+		ForkDigest:     common.ForkDigest{0x01, 0x02, 0x03, 0x04},
+		FinalizedRoot:  common.Root{0xaa},
+		FinalizedEpoch: 42,
+		HeadRoot:       common.Root{0xbb},
+		HeadSlot:       100,
+	}
+
+	v2 := eth.StatusV2FromV1(v1)
+
+	assert.Equal(t, v1.ForkDigest, v2.ForkDigest)
+	assert.Equal(t, v1.FinalizedRoot, v2.FinalizedRoot)
+	assert.Equal(t, v1.FinalizedEpoch, v2.FinalizedEpoch)
+	assert.Equal(t, v1.HeadRoot, v2.HeadRoot)
+	assert.Equal(t, v1.HeadSlot, v2.HeadSlot)
+	assert.Equal(t, common.Slot(0), v2.EarliestAvailableSlot)
+}
+
+func TestStatusV2_RoundTrip(t *testing.T) {
+	original := &common.Status{
+		ForkDigest:     common.ForkDigest{0xde, 0xad, 0xbe, 0xef},
+		FinalizedRoot:  common.Root{0x11, 0x22, 0x33},
+		FinalizedEpoch: 999,
+		HeadRoot:       common.Root{0x44, 0x55, 0x66},
+		HeadSlot:       12345,
+	}
+
+	// V1 -> V2 -> V1 should preserve all shared fields.
+	v2 := eth.StatusV2FromV1(original)
+	result := v2.ToV1()
+
+	assert.Equal(t, original, result)
+}

--- a/pkg/consensus/mimicry/p2p/eth/topic.go
+++ b/pkg/consensus/mimicry/p2p/eth/topic.go
@@ -8,16 +8,19 @@ const (
 	ProtocolSuffix    = encoder.ProtocolSuffixSSZSnappy
 	ProtocolVersionV1 = "1"
 	ProtocolVersionV2 = "2"
+	ProtocolVersionV3 = "3"
 )
 
 // Request-Response Protocol IDs.
 const (
 	StatusV1ProtocolID  = "/eth2/beacon_chain/req/status/" + ProtocolVersionV1 + "/" + ProtocolSuffix
+	StatusV2ProtocolID  = "/eth2/beacon_chain/req/status/" + ProtocolVersionV2 + "/" + ProtocolSuffix
 	GoodbyeV1ProtocolID = "/eth2/beacon_chain/req/goodbye/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	PingV1ProtocolID    = "/eth2/beacon_chain/req/ping/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 
 	MetaDataV1ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	MetaDataV2ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV2 + "/" + ProtocolSuffix
+	MetaDataV3ProtocolID = "/eth2/beacon_chain/req/metadata/" + ProtocolVersionV3 + "/" + ProtocolSuffix
 
 	BeaconBlocksByRangeV1ProtocolID = "/eth2/beacon_chain/req/beacon_blocks_by_range/" + ProtocolVersionV1 + "/" + ProtocolSuffix
 	BeaconBlocksByRangeV2ProtocolID = "/eth2/beacon_chain/req/beacon_blocks_by_range/" + ProtocolVersionV2 + "/" + ProtocolSuffix

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -422,12 +422,11 @@ func cleanupNetwork(t *testing.T, config *NetworkConfig) error {
 // createParticipantConfig creates participant configuration based on NetworkConfig.
 func createParticipantConfig(config *NetworkConfig) []epgconfig.ParticipantConfig {
 	// Default participant configuration with diverse client types.
-	// Note: Post-Fulu, Prysm and Lodestar only support status/2 which
-	// the crawler doesn't yet implement. Use lighthouse and teku which
-	// still support status/1 until status/2 is added.
 	participants := []epgconfig.ParticipantConfig{
-		{ELType: "geth", CLType: "lighthouse", Count: 2},
-		{ELType: "geth", CLType: "teku", Count: 2},
+		{ELType: "geth", CLType: "lighthouse", Count: 1},
+		{ELType: "geth", CLType: "teku", Count: 1},
+		{ELType: "geth", CLType: "prysm", Count: 1},
+		{ELType: "geth", CLType: "lodestar", Count: 1},
 	}
 
 	// Adjust based on the number of participants requested


### PR DESCRIPTION
## Summary
- Define `StatusV2` (92 bytes, adds `earliest_available_slot`) and `MetaDataV3` (25 bytes, adds `custody_group_count`) SSZ types following the Fulu consensus spec
- `RequestStatusFromPeer` tries status/2 first, falls back to status/1 on protocol negotiation failure
- `RequestMetadataFromPeer` tries metadata/3 first, falls back to metadata/2
- Register inbound handlers for both protocol versions so peers using either version can exchange status/metadata with the crawler
- Re-enable Prysm and Lodestar in Kurtosis integration tests (they were excluded because they only support status/2 post-Fulu)