### PR TITLE
[codex] improve execution mimicry protocol support

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,5 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.12.1
           args: --timeout=10m
+          only-new-issues: true

--- a/pkg/consensus/mimicry/crawler/main_test.go
+++ b/pkg/consensus/mimicry/crawler/main_test.go
@@ -25,10 +25,8 @@ func TestMain(m *testing.M) {
 
 	// Start with default configuration
 	defaultConfig := kurtosis.DefaultNetworkConfig()
-	// Use shared enclave name for all tests
-	defaultConfig.Name = "ethcore-test"
-	// Use same port offset since we're sharing the same enclave
-	defaultConfig.PortOffset = 0
+	defaultConfig.Name = "ethcore-crawler-test"
+	defaultConfig.PortOffset = 1000
 
 	// Get configuration from environment
 	envConfig, err := kurtosis.ConfigFromEnvironment()

--- a/pkg/execution/mimicry/client.go
+++ b/pkg/execution/mimicry/client.go
@@ -21,6 +21,11 @@ import (
 
 const (
 	RLPXOffset = 0x10 // https://github.com/ethereum/devp2p/blob/master/rlpx.md#message-id-based-multiplexing
+
+	logFieldCode         = "code"
+	logFieldRequestID    = "request_id"
+	logFieldHeadersCount = "headers_count"
+	logFieldETHCap       = "ethCapVersion"
 )
 
 type Client struct {
@@ -38,11 +43,32 @@ type Client struct {
 
 	conn     net.Conn
 	rlpxConn *rlpx.Conn
+	writeMu  sync.Mutex
 
 	pooledTransactionsMap map[uint64]chan *PooledTransactions
 	pooledTransactionsMux sync.Mutex
 
 	ethCapVersion uint
+	statusSent    bool
+
+	statusProvider  StatusProvider
+	headerProvider  HeaderProvider
+	bodyProvider    BodyProvider
+	receiptProvider ReceiptProvider
+}
+
+var defaultPrivateKey = struct {
+	sync.Once
+	key *ecdsa.PrivateKey
+	err error
+}{}
+
+func defaultNodePrivateKey() (*ecdsa.PrivateKey, error) {
+	defaultPrivateKey.Do(func() {
+		defaultPrivateKey.key, defaultPrivateKey.err = crypto.GenerateKey()
+	})
+
+	return defaultPrivateKey.key, defaultPrivateKey.err
 }
 
 func parseNodeRecord(record string) (*enode.Node, error) {
@@ -53,19 +79,25 @@ func parseNodeRecord(record string) (*enode.Node, error) {
 	return enode.Parse(enode.ValidSchemes, record)
 }
 
-func New(ctx context.Context, log logrus.FieldLogger, record, name string) (*Client, error) {
+func New(ctx context.Context, log logrus.FieldLogger, record, name string, opts ...Option) (*Client, error) {
 	nodeRecord, err := parseNodeRecord(record)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{
+	client := &Client{
 		log:                   log.WithField("node_record", nodeRecord.String()),
 		nodeRecord:            nodeRecord,
 		name:                  name,
 		broker:                emission.NewEmitter(),
 		pooledTransactionsMap: map[uint64]chan *PooledTransactions{},
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client, nil
 }
 
 func (c *Client) Start(ctx context.Context) error {
@@ -98,7 +130,12 @@ func (c *Client) Start(ctx context.Context) error {
 		return err
 	}
 
-	c.privateKey, _ = crypto.GenerateKey()
+	if c.privateKey == nil {
+		c.privateKey, err = defaultNodePrivateKey()
+		if err != nil {
+			return err
+		}
+	}
 
 	peerPublicKey, err := c.rlpxConn.Handshake(c.privateKey)
 	if err != nil {
@@ -150,6 +187,21 @@ func (c *Client) Stop(ctx context.Context) error {
 func (c *Client) handleSessionError(ctx context.Context, err error) {
 	c.log.WithError(err).Debug("error handling session")
 	c.disconnect(ctx, nil)
+}
+
+func (c *Client) writeRLPx(code uint64, data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if c.rlpxConn == nil {
+		return fmt.Errorf("rlpx connection is not initialized")
+	}
+
+	if _, err := c.rlpxConn.Write(code, data); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Client) disconnect(ctx context.Context, reason *Disconnect) {
@@ -234,6 +286,12 @@ func (c *Client) startSession(ctx context.Context) {
 
 				return
 			}
+		case GetPooledTransactionsCode:
+			if err := c.handleGetPooledTransactions(ctx, code, data); err != nil {
+				c.handleSessionError(ctx, err)
+
+				return
+			}
 		case PooledTransactionsCode:
 			if err := c.handlePooledTransactions(ctx, code, data); err != nil {
 				c.handleSessionError(ctx, err)
@@ -253,7 +311,7 @@ func (c *Client) startSession(ctx context.Context) {
 				return
 			}
 		default:
-			c.log.WithField("code", code).Debug("received unhandled message code")
+			c.log.WithField(logFieldCode, code).Debug("received unhandled message code")
 		}
 	}
 }

--- a/pkg/execution/mimicry/client_test.go
+++ b/pkg/execution/mimicry/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,4 +192,23 @@ func TestNew(t *testing.T) {
 
 func TestClientConstants(t *testing.T) {
 	assert.Equal(t, 0x10, RLPXOffset, "RLPXOffset should be 0x10 per RLPx spec")
+}
+
+func TestDefaultNodePrivateKeyIsProcessStable(t *testing.T) {
+	first, err := defaultNodePrivateKey()
+	require.NoError(t, err)
+	second, err := defaultNodePrivateKey()
+	require.NoError(t, err)
+
+	assert.Same(t, first, second)
+}
+
+func TestWithPrivateKey(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	client := &Client{}
+	WithPrivateKey(key)(client)
+
+	assert.Same(t, key, client.privateKey)
 }

--- a/pkg/execution/mimicry/constants_test.go
+++ b/pkg/execution/mimicry/constants_test.go
@@ -19,8 +19,8 @@ func TestP2PProtocolVersionConstants(t *testing.T) {
 }
 
 func TestETHProtocolVersionConstants(t *testing.T) {
-	assert.Equal(t, uint(69), minETHProtocolVersion)
-	assert.Equal(t, uint(69), maxETHProtocolVersion)
+	assert.Equal(t, uint(68), minETHProtocolVersion)
+	assert.Equal(t, uint(70), maxETHProtocolVersion)
 }
 
 func TestETHCapNameConstant(t *testing.T) {

--- a/pkg/execution/mimicry/message_block_bodies.go
+++ b/pkg/execution/mimicry/message_block_bodies.go
@@ -22,9 +22,9 @@ func (msg *BlockBodies) ReqID() uint64 { return msg.RequestId }
 
 func (c *Client) sendBlockBodies(ctx context.Context, bh *BlockBodies) error {
 	c.log.WithFields(logrus.Fields{
-		"code":         BlockBodiesCode,
-		"request_id":   bh.RequestId,
-		"bodies_count": bh.List.Len(),
+		logFieldCode:      BlockBodiesCode,
+		logFieldRequestID: bh.RequestId,
+		"bodies_count":    bh.List.Len(),
 	}).Debug("sending BlockBodies")
 
 	encodedData, err := rlp.EncodeToBytes(bh)
@@ -32,7 +32,7 @@ func (c *Client) sendBlockBodies(ctx context.Context, bh *BlockBodies) error {
 		return fmt.Errorf("error encoding block bodies: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(BlockBodiesCode, encodedData); err != nil {
+	if err := c.writeRLPx(BlockBodiesCode, encodedData); err != nil {
 		return fmt.Errorf("error sending block bodies: %w", err)
 	}
 

--- a/pkg/execution/mimicry/message_block_headers.go
+++ b/pkg/execution/mimicry/message_block_headers.go
@@ -30,26 +30,26 @@ func (c *Client) receiveBlockHeaders(ctx context.Context, data []byte) (*BlockHe
 }
 
 func (c *Client) handleBlockHeaders(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received BlockHeaders")
+	c.log.WithField(logFieldCode, code).Debug("received BlockHeaders")
 
 	blockHeaders, err := c.receiveBlockHeaders(ctx, data)
 	if err != nil {
 		return err
 	}
 
-	err = c.sendBlockHeaders(ctx, blockHeaders)
-	if err != nil {
-		return err
-	}
+	c.log.WithFields(logrus.Fields{
+		logFieldRequestID:    blockHeaders.RequestId,
+		logFieldHeadersCount: blockHeaders.List.Len(),
+	}).Debug("ignoring unsolicited BlockHeaders")
 
 	return nil
 }
 
 func (c *Client) sendBlockHeaders(ctx context.Context, bh *BlockHeaders) error {
 	c.log.WithFields(logrus.Fields{
-		"code":          BlockHeadersCode,
-		"request_id":    bh.RequestId,
-		"headers_count": bh.List.Len(),
+		logFieldCode:         BlockHeadersCode,
+		logFieldRequestID:    bh.RequestId,
+		logFieldHeadersCount: bh.List.Len(),
 	}).Debug("sending BlockHeaders")
 
 	encodedData, err := rlp.EncodeToBytes(bh)
@@ -57,7 +57,7 @@ func (c *Client) sendBlockHeaders(ctx context.Context, bh *BlockHeaders) error {
 		return fmt.Errorf("error encoding block headers: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(BlockHeadersCode, encodedData); err != nil {
+	if err := c.writeRLPx(BlockHeadersCode, encodedData); err != nil {
 		return fmt.Errorf("error sending block headers: %w", err)
 	}
 

--- a/pkg/execution/mimicry/message_block_range_update.go
+++ b/pkg/execution/mimicry/message_block_range_update.go
@@ -28,7 +28,7 @@ func (c *Client) receiveBlockRangeUpdate(ctx context.Context, data []byte) (*Blo
 }
 
 func (c *Client) handleBlockRangeUpdate(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received BlockRangeUpdate")
+	c.log.WithField(logFieldCode, code).Debug("received BlockRangeUpdate")
 
 	blockRangeUpdate, err := c.receiveBlockRangeUpdate(ctx, data)
 	if err != nil {

--- a/pkg/execution/mimicry/message_disconnect.go
+++ b/pkg/execution/mimicry/message_disconnect.go
@@ -3,9 +3,12 @@ package mimicry
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/golang/snappy"
 )
 
 const (
@@ -21,25 +24,73 @@ func (h *Disconnect) Code() int { return DisconnectCode }
 func (h *Disconnect) ReqID() uint64 { return 0 }
 
 func (c *Client) receiveDisconnect(ctx context.Context, data []byte) *Disconnect {
-	d := new(p2p.DiscReason)
+	reason, err := decodeDisconnectReason(data)
+	if err != nil {
+		c.log.WithError(err).WithField("raw", hexutil.Encode(data)).Debug("Error decoding disconnect")
+	}
 
-	if len(data) > 0 {
-		reason := data[0:1]
-		// besu sends 2 byte disconnect message
-		if len(data) > 1 {
-			reason = data[1:2]
-		}
+	return &Disconnect{Reason: reason}
+}
 
-		if err := rlp.DecodeBytes(reason, &d); err != nil {
-			c.log.WithError(err).Debug("Error decoding disconnect")
+func decodeDisconnectReason(data []byte) (p2p.DiscReason, error) {
+	if len(data) == 0 {
+		return p2p.DiscInvalid, nil
+	}
+
+	reason, err := decodeDisconnectReasonRLP(data)
+	if err == nil {
+		return reason, nil
+	}
+
+	if decoded, snappyErr := snappy.Decode(nil, data); snappyErr == nil {
+		if reason, snappyDecodeErr := decodeDisconnectReasonRLP(decoded); snappyDecodeErr == nil {
+			return reason, nil
 		}
 	}
 
-	return &Disconnect{Reason: *d}
+	return p2p.DiscInvalid, err
+}
+
+func decodeDisconnectReasonRLP(data []byte) (p2p.DiscReason, error) {
+	if len(data) == 0 {
+		return p2p.DiscInvalid, nil
+	}
+
+	if data[0] >= 0xc0 {
+		var elements []rlp.RawValue
+		if err := rlp.DecodeBytes(data, &elements); err != nil {
+			return p2p.DiscInvalid, err
+		}
+
+		if len(elements) == 0 {
+			return p2p.DiscInvalid, nil
+		}
+
+		var reasonBytes []byte
+		if err := rlp.DecodeBytes(elements[0], &reasonBytes); err != nil {
+			return p2p.DiscInvalid, err
+		}
+
+		if len(reasonBytes) != 1 {
+			return p2p.DiscInvalid, nil
+		}
+
+		return p2p.DiscReason(reasonBytes[0]), nil
+	}
+
+	reason := new(p2p.DiscReason)
+	if err := rlp.DecodeBytes(data, reason); err != nil {
+		return p2p.DiscInvalid, fmt.Errorf("decode legacy disconnect reason: %w", err)
+	}
+
+	return *reason, nil
 }
 
 func (c *Client) handleDisconnect(ctx context.Context, code uint64, data []byte) {
-	c.log.WithField("code", code).Debug("received Disconnect")
+	c.log.WithFields(map[string]any{
+		logFieldCode: code,
+		"raw":        hexutil.Encode(data),
+	}).Debug("received Disconnect")
 
 	disconnect := c.receiveDisconnect(ctx, data)
 

--- a/pkg/execution/mimicry/message_disconnect_test.go
+++ b/pkg/execution/mimicry/message_disconnect_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDisconnectCode(t *testing.T) {
@@ -49,4 +51,57 @@ func TestDisconnectReasons(t *testing.T) {
 func TestDisconnectCodeConstant(t *testing.T) {
 	// DisconnectCode should be 0x01 per RLPx spec
 	assert.Equal(t, 0x01, DisconnectCode)
+}
+
+func TestDecodeDisconnectReason(t *testing.T) {
+	legacy, err := rlp.EncodeToBytes(p2p.DiscTooManyPeers)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		data []byte
+		want p2p.DiscReason
+	}{
+		{
+			name: "legacy scalar reason",
+			data: legacy,
+			want: p2p.DiscTooManyPeers,
+		},
+		{
+			name: "besu list reason",
+			data: []byte{0xc1, byte(p2p.DiscTooManyPeers)},
+			want: p2p.DiscTooManyPeers,
+		},
+		{
+			name: "besu unknown empty reason",
+			data: []byte{0xc1, 0x80},
+			want: p2p.DiscInvalid,
+		},
+		{
+			name: "snappy compressed list reason",
+			data: []byte{0x02, 0x04, 0xc1, byte(p2p.DiscTooManyPeers)},
+			want: p2p.DiscTooManyPeers,
+		},
+		{
+			name: "empty payload",
+			data: nil,
+			want: p2p.DiscInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeDisconnectReason(tt.data)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecodeDisconnectReasonHandlesSnappyEmptyPayload(t *testing.T) {
+	require.NotPanics(t, func() {
+		got, err := decodeDisconnectReason([]byte{0x00})
+		require.NoError(t, err)
+		assert.Equal(t, p2p.DiscReason(p2p.DiscInvalid), got)
+	})
 }

--- a/pkg/execution/mimicry/message_get_block_bodies.go
+++ b/pkg/execution/mimicry/message_get_block_bodies.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -29,15 +30,36 @@ func (c *Client) receiveGetBlockBodies(ctx context.Context, data []byte) (*GetBl
 }
 
 func (c *Client) handleGetBlockBodies(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received GetBlockBodies")
+	c.log.WithField(logFieldCode, code).Debug("received GetBlockBodies")
 
 	blockBodies, err := c.receiveGetBlockBodies(ctx, data)
 	if err != nil {
 		return err
 	}
 
+	var list rlp.RawList[eth.BlockBody]
+
+	if c.bodyProvider != nil {
+		bodies, berr := c.bodyProvider(ctx, blockBodies.GetBlockBodiesRequest)
+		if berr != nil {
+			return fmt.Errorf("fetch block bodies: %w", berr)
+		}
+
+		list, err = rlp.EncodeToRawList(bodies)
+		if err != nil {
+			return fmt.Errorf("encode block bodies: %w", err)
+		}
+	}
+
+	c.log.WithFields(logrus.Fields{
+		logFieldRequestID: blockBodies.RequestId,
+		"requested_count": len(blockBodies.GetBlockBodiesRequest),
+		"response_count":  list.Len(),
+	}).Debug("responding to GetBlockBodies")
+
 	err = c.sendBlockBodies(ctx, &BlockBodies{
 		RequestId: blockBodies.RequestId,
+		List:      list,
 	})
 	if err != nil {
 		return err

--- a/pkg/execution/mimicry/message_get_block_headers.go
+++ b/pkg/execution/mimicry/message_get_block_headers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/sirupsen/logrus"
@@ -30,35 +31,43 @@ func (c *Client) receiveGetBlockHeaders(ctx context.Context, data []byte) (*GetB
 }
 
 func (c *Client) handleGetBlockHeaders(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received GetBlockHeaders")
+	c.log.WithField(logFieldCode, code).Debug("received GetBlockHeaders")
 
 	blockHeaders, err := c.receiveGetBlockHeaders(ctx, data)
 	if err != nil {
 		return err
 	}
 
-	err = c.sendGetBlockHeaders(ctx, blockHeaders)
+	var headersList rlp.RawList[*types.Header]
+
+	if c.headerProvider != nil && blockHeaders.GetBlockHeadersRequest != nil {
+		headers, herr := c.headerProvider(ctx, blockHeaders.GetBlockHeadersRequest)
+		if herr != nil {
+			c.log.WithError(herr).Debug("failed to provide block headers")
+		} else {
+			headersList, err = rlp.EncodeToRawList(headers)
+			if err != nil {
+				return fmt.Errorf("error encoding provided block headers: %w", err)
+			}
+		}
+	}
+
+	c.log.WithFields(logrus.Fields{
+		logFieldRequestID:    blockHeaders.RequestId,
+		logFieldHeadersCount: headersList.Len(),
+		"amount":             blockHeaders.Amount,
+		"origin_hash":        blockHeaders.Origin.Hash,
+		"origin_number":      blockHeaders.Origin.Number,
+		"skip":               blockHeaders.Skip,
+		"reverse":            blockHeaders.Reverse,
+	}).Debug("responding to GetBlockHeaders")
+
+	err = c.sendBlockHeaders(ctx, &BlockHeaders{
+		RequestId: blockHeaders.RequestId,
+		List:      headersList,
+	})
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (c *Client) sendGetBlockHeaders(ctx context.Context, bh *GetBlockHeaders) error {
-	c.log.WithFields(logrus.Fields{
-		"code":       GetBlockHeadersCode,
-		"request_id": bh.RequestId,
-		"headers":    bh.GetBlockHeadersRequest,
-	}).Debug("sending GetBlockHeaders")
-
-	encodedData, err := rlp.EncodeToBytes(bh)
-	if err != nil {
-		return fmt.Errorf("error encoding get block headers: %w", err)
-	}
-
-	if _, err := c.rlpxConn.Write(GetBlockHeadersCode, encodedData); err != nil {
-		return fmt.Errorf("error sending get block headers: %w", err)
 	}
 
 	return nil

--- a/pkg/execution/mimicry/message_get_pooled_transactions.go
+++ b/pkg/execution/mimicry/message_get_pooled_transactions.go
@@ -23,20 +23,42 @@ func (msg *GetPooledTransactions) Code() int { return GetPooledTransactionsCode 
 
 func (msg *GetPooledTransactions) ReqID() uint64 { return msg.RequestId }
 
+func (c *Client) receiveGetPooledTransactions(ctx context.Context, data []byte) (*GetPooledTransactions, error) {
+	s := new(GetPooledTransactions)
+	if err := rlp.DecodeBytes(data, &s); err != nil {
+		return nil, fmt.Errorf("error decoding get pooled transactions: %w", err)
+	}
+
+	return s, nil
+}
+
+func (c *Client) handleGetPooledTransactions(ctx context.Context, code uint64, data []byte) error {
+	c.log.WithField(logFieldCode, code).Debug("received GetPooledTransactions")
+
+	txs, err := c.receiveGetPooledTransactions(ctx, data)
+	if err != nil {
+		return err
+	}
+
+	return c.sendPooledTransactions(ctx, &PooledTransactions{
+		RequestId: txs.RequestId,
+	})
+}
+
 func (c *Client) sendGetPooledTransactions(ctx context.Context, pt *GetPooledTransactions) error {
 	c.log.WithFields(logrus.Fields{
-		"code":       GetPooledTransactionsCode,
-		"request_id": pt.RequestId,
-		"txs_count":  len(pt.GetPooledTransactionsRequest),
+		logFieldCode:      GetPooledTransactionsCode,
+		logFieldRequestID: pt.RequestId,
+		"txs_count":       len(pt.GetPooledTransactionsRequest),
 	}).Debug("sending GetPooledTransactions")
 
 	encodedData, err := rlp.EncodeToBytes(pt)
 	if err != nil {
-		return fmt.Errorf("error encoding get block headers: %w", err)
+		return fmt.Errorf("error encoding get pooled transactions: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(GetPooledTransactionsCode, encodedData); err != nil {
-		return fmt.Errorf("error sending get block headers: %w", err)
+	if err := c.writeRLPx(GetPooledTransactionsCode, encodedData); err != nil {
+		return fmt.Errorf("error sending get pooled transactions: %w", err)
 	}
 
 	return nil

--- a/pkg/execution/mimicry/message_get_receipts.go
+++ b/pkg/execution/mimicry/message_get_receipts.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -20,30 +20,102 @@ func (msg *GetReceipts) Code() int { return GetReceiptsCode }
 
 func (msg *GetReceipts) ReqID() uint64 { return msg.RequestId }
 
-func (c *Client) receiveGetReceipts(ctx context.Context, data []byte) (*GetReceipts, error) {
-	s := new(GetReceipts)
-	if err := rlp.DecodeBytes(data, &s); err != nil {
-		return nil, fmt.Errorf("error decoding get block receipts: %w", err)
+func (msg *GetReceipts) ReceiptRequest() ReceiptRequest {
+	return ReceiptRequest{
+		Hashes: msg.GetReceiptsRequest,
 	}
+}
 
-	return s, nil
+type GetReceipts70Packet struct {
+	RequestId              uint64
+	FirstBlockReceiptIndex uint64
+	eth.GetReceiptsRequest
+}
+
+type GetReceipts70 struct {
+	GetReceipts70Packet
+}
+
+func (msg *GetReceipts70) Code() int { return GetReceiptsCode }
+
+func (msg *GetReceipts70) ReqID() uint64 { return msg.RequestId }
+
+func (msg *GetReceipts70) ReceiptRequest() ReceiptRequest {
+	return ReceiptRequest{
+		Hashes:                 msg.GetReceiptsRequest,
+		FirstBlockReceiptIndex: msg.FirstBlockReceiptIndex,
+	}
+}
+
+type GetReceiptsMessage interface {
+	Code() int
+	ReqID() uint64
+	ReceiptRequest() ReceiptRequest
+}
+
+func (c *Client) receiveGetReceipts(ctx context.Context, data []byte) (GetReceiptsMessage, error) {
+	switch c.ethCapVersion {
+	case 70:
+		s := new(GetReceipts70)
+		if err := rlp.DecodeBytes(data, &s.GetReceipts70Packet); err != nil {
+			return nil, fmt.Errorf("error decoding eth/70 get block receipts: %w", err)
+		}
+
+		return s, nil
+	default:
+		s := new(GetReceipts)
+		if err := rlp.DecodeBytes(data, &s); err != nil {
+			return nil, fmt.Errorf("error decoding get block receipts: %w", err)
+		}
+
+		return s, nil
+	}
 }
 
 func (c *Client) handleGetReceipts(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received GetReceipts")
+	c.log.WithField(logFieldCode, code).Debug("received GetReceipts")
 
-	blockBodies, err := c.receiveGetReceipts(ctx, data)
+	request, err := c.receiveGetReceipts(ctx, data)
 	if err != nil {
 		return err
 	}
 
-	pkt := eth.ReceiptsPacket{RequestId: blockBodies.RequestId}
+	var list rlp.RawList[*eth.ReceiptList]
 
-	if appendErr := pkt.List.Append(eth.NewReceiptList([]*types.Receipt{})); appendErr != nil {
-		return fmt.Errorf("error constructing empty receipts: %w", appendErr)
+	receiptRequest := request.ReceiptRequest()
+
+	if c.receiptProvider != nil {
+		receipts, rerr := c.receiptProvider(ctx, receiptRequest)
+		if rerr != nil {
+			return fmt.Errorf("fetch receipts: %w", rerr)
+		}
+
+		list, err = rlp.EncodeToRawList(receipts)
+		if err != nil {
+			return fmt.Errorf("encode receipts: %w", err)
+		}
 	}
 
-	receipts := &Receipts69{ReceiptsPacket: pkt}
+	c.log.WithFields(logrus.Fields{
+		logFieldRequestID:           request.ReqID(),
+		"first_block_receipt_index": receiptRequest.FirstBlockReceiptIndex,
+		"requested_count":           len(receiptRequest.Hashes),
+		"response_count":            list.Len(),
+	}).Debug("responding to GetReceipts")
+
+	var receipts Receipts
+	if c.ethCapVersion >= 70 {
+		receipts = &Receipts70{Receipts70Packet: Receipts70Packet{
+			RequestId:           request.ReqID(),
+			LastBlockIncomplete: false,
+			List:                list,
+		}}
+	} else {
+		receipts = &Receipts69{ReceiptsPacket: eth.ReceiptsPacket{
+			RequestId: request.ReqID(),
+			List:      list,
+		}}
+	}
 
 	err = c.sendReceipts(ctx, receipts)
 	if err != nil {

--- a/pkg/execution/mimicry/message_hello.go
+++ b/pkg/execution/mimicry/message_hello.go
@@ -15,8 +15,8 @@ const (
 	HelloCode             = 0x00
 	P2PProtocolVersion    = 5
 	minP2PProtocolVersion = 5
-	minETHProtocolVersion = uint(69)
-	maxETHProtocolVersion = uint(69)
+	minETHProtocolVersion = uint(68)
+	maxETHProtocolVersion = uint(70)
 	ETHCapName            = "eth"
 )
 
@@ -51,13 +51,13 @@ func (h *Hello) Validate() error {
 		return fmt.Errorf("peer is using unsupported p2p protocol version: %d", h.Version)
 	}
 
-	supportsOurETHProtocolVersion := false
+	supportsSupportedETHProtocolVersion := false
 	highestETHProtocolVersion := uint(0)
 
 	for _, cap := range h.Caps {
 		if cap.Name == ETHCapName {
-			if cap.Version == minETHProtocolVersion {
-				supportsOurETHProtocolVersion = true
+			if cap.Version >= minETHProtocolVersion && cap.Version <= maxETHProtocolVersion {
+				supportsSupportedETHProtocolVersion = true
 			}
 
 			if cap.Version > highestETHProtocolVersion {
@@ -70,8 +70,8 @@ func (h *Hello) Validate() error {
 		return fmt.Errorf("peer does not support eth protocol")
 	}
 
-	if !supportsOurETHProtocolVersion {
-		return fmt.Errorf("peer is using unsupported eth protocol version: %d", minETHProtocolVersion)
+	if !supportsSupportedETHProtocolVersion {
+		return fmt.Errorf("peer is using unsupported eth protocol version: %d", highestETHProtocolVersion)
 	}
 
 	return nil
@@ -93,11 +93,15 @@ func (h *Hello) ETHProtocolVersion() uint {
 
 func SupportedEthCaps() []p2p.Cap {
 	caps := []p2p.Cap{}
-	for i := minETHProtocolVersion; i <= maxETHProtocolVersion; i++ {
+	for i := maxETHProtocolVersion; i >= minETHProtocolVersion; i-- {
 		caps = append(caps, p2p.Cap{
 			Name:    ETHCapName,
 			Version: i,
 		})
+
+		if i == 0 {
+			break
+		}
 	}
 
 	return caps
@@ -124,14 +128,16 @@ func (c *Client) receiveHello(ctx context.Context, data []byte) (*Hello, error) 
 
 func (c *Client) sendHello(ctx context.Context) error {
 	c.log.WithFields(logrus.Fields{
-		"code": HelloCode,
+		logFieldCode: HelloCode,
 	}).Debug("sending Hello")
 
 	pub0 := crypto.FromECDSAPub(&c.privateKey.PublicKey)[1:]
 	hello := &Hello{
-		Version: P2PProtocolVersion,
-		Caps:    SupportedEthCaps(),
-		ID:      pub0,
+		Version:    P2PProtocolVersion,
+		Name:       c.name,
+		Caps:       SupportedEthCaps(),
+		ListenPort: 0,
+		ID:         pub0,
 	}
 
 	encodedData, err := rlp.EncodeToBytes(hello)
@@ -139,7 +145,7 @@ func (c *Client) sendHello(ctx context.Context) error {
 		return fmt.Errorf("error encoding hello: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(HelloCode, encodedData); err != nil {
+	if err := c.writeRLPx(HelloCode, encodedData); err != nil {
 		return fmt.Errorf("error sending hello: %w", err)
 	}
 
@@ -147,7 +153,7 @@ func (c *Client) sendHello(ctx context.Context) error {
 }
 
 func (c *Client) handleHello(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received Hello")
+	c.log.WithField(logFieldCode, code).Debug("received Hello")
 
 	hello, err := c.receiveHello(ctx, data)
 	if err != nil {
@@ -160,6 +166,19 @@ func (c *Client) handleHello(ctx context.Context, code uint64, data []byte) erro
 
 	// always enable snappy to avoid jank
 	c.rlpxConn.SetSnappy(true)
+
+	if c.statusProvider != nil && !c.statusSent {
+		status, err := c.statusProvider(ctx, c.ethCapVersion, nil)
+		if err != nil {
+			return fmt.Errorf("failed to build initial provided Status: %w", err)
+		}
+
+		if status != nil {
+			if err := c.sendStatus(ctx, status); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/pkg/execution/mimicry/message_hello_test.go
+++ b/pkg/execution/mimicry/message_hello_test.go
@@ -56,7 +56,7 @@ func TestHelloValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "ETH 68 only is invalid",
+			name: "valid hello with ETH 68 only",
 			hello: &Hello{
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
@@ -66,8 +66,7 @@ func TestHelloValidate(t *testing.T) {
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
 			},
-			wantErr: true,
-			errMsg:  "peer is using unsupported eth protocol version",
+			wantErr: false,
 		},
 		{
 			name: "invalid P2P protocol version",
@@ -125,12 +124,25 @@ func TestHelloValidate(t *testing.T) {
 			errMsg:  "peer is using unsupported eth protocol version",
 		},
 		{
-			name: "only future unsupported ETH version",
+			name: "valid hello with ETH 70 only",
 			hello: &Hello{
 				Version: P2PProtocolVersion,
 				Name:    "test-client",
 				Caps: []p2p.Cap{
 					{Name: ETHCapName, Version: 70},
+				},
+				ListenPort: 30303,
+				ID:         make([]byte, 64),
+			},
+			wantErr: false,
+		},
+		{
+			name: "only future unsupported ETH version",
+			hello: &Hello{
+				Version: P2PProtocolVersion,
+				Name:    "test-client",
+				Caps: []p2p.Cap{
+					{Name: ETHCapName, Version: 71},
 				},
 				ListenPort: 30303,
 				ID:         make([]byte, 64),
@@ -168,26 +180,26 @@ func TestHelloETHProtocolVersion(t *testing.T) {
 			expected: 69,
 		},
 		{
-			name: "ETH 68 returns 0 since below min",
+			name: "ETH 68 only",
 			caps: []p2p.Cap{
 				{Name: ETHCapName, Version: 68},
 			},
-			expected: 0,
+			expected: 68,
 		},
 		{
-			name: "ETH 70 unsupported returns 69 if present",
+			name: "ETH 70 returns highest supported version",
 			caps: []p2p.Cap{
 				{Name: ETHCapName, Version: 69},
 				{Name: ETHCapName, Version: 70},
 			},
-			expected: 69,
+			expected: 70,
 		},
 		{
-			name: "only ETH 70 returns 0 since it exceeds max",
+			name: "only ETH 70 returns 70",
 			caps: []p2p.Cap{
 				{Name: ETHCapName, Version: 70},
 			},
-			expected: 0,
+			expected: 70,
 		},
 		{
 			name:     "no ETH caps returns 0",
@@ -284,10 +296,14 @@ func TestHelloETHCap(t *testing.T) {
 func TestSupportedEthCaps(t *testing.T) {
 	caps := SupportedEthCaps()
 
-	require.Len(t, caps, 1, "should support ETH 69 only")
+	require.Len(t, caps, 3, "should support ETH 70, ETH 69, and ETH 68")
 
 	assert.Equal(t, ETHCapName, caps[0].Name)
-	assert.Equal(t, uint(69), caps[0].Version)
+	assert.Equal(t, uint(70), caps[0].Version)
+	assert.Equal(t, ETHCapName, caps[1].Name)
+	assert.Equal(t, uint(69), caps[1].Version)
+	assert.Equal(t, ETHCapName, caps[2].Name)
+	assert.Equal(t, uint(68), caps[2].Version)
 }
 
 func TestHelloRLPEncoding(t *testing.T) {

--- a/pkg/execution/mimicry/message_new_pooled_transaction_hashes.go
+++ b/pkg/execution/mimicry/message_new_pooled_transaction_hashes.go
@@ -29,7 +29,7 @@ func (c *Client) receiveNewPooledTransactionHashes(ctx context.Context, data []b
 }
 
 func (c *Client) handleNewPooledTransactionHashes(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received NewPooledTransactionHashes")
+	c.log.WithField(logFieldCode, code).Debug("received NewPooledTransactionHashes")
 
 	hashes, err := c.receiveNewPooledTransactionHashes(ctx, data)
 	if err != nil {

--- a/pkg/execution/mimicry/message_ping.go
+++ b/pkg/execution/mimicry/message_ping.go
@@ -14,7 +14,7 @@ func (h *Ping) Code() int { return PingCode }
 func (h *Ping) ReqID() uint64 { return 0 }
 
 func (c *Client) handlePing(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received Ping")
+	c.log.WithField(logFieldCode, code).Debug("received Ping")
 
 	if err := c.sendPong(ctx); err != nil {
 		return err

--- a/pkg/execution/mimicry/message_pong.go
+++ b/pkg/execution/mimicry/message_pong.go
@@ -20,10 +20,10 @@ func (h *Pong) ReqID() uint64 { return 0 }
 
 func (c *Client) sendPong(ctx context.Context) error {
 	c.log.WithFields(logrus.Fields{
-		"code": PongCode,
+		logFieldCode: PongCode,
 	}).Debug("sending Pong")
 
-	if _, err := c.rlpxConn.Write(PongCode, []byte{}); err != nil {
+	if err := c.writeRLPx(PongCode, []byte{}); err != nil {
 		return fmt.Errorf("error sending pong: %w", err)
 	}
 

--- a/pkg/execution/mimicry/message_pooled_transactions.go
+++ b/pkg/execution/mimicry/message_pooled_transactions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -29,7 +30,7 @@ func (c *Client) receivePooledTransactions(ctx context.Context, data []byte) (*P
 }
 
 func (c *Client) handlePooledTransactions(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received PooledTransactions")
+	c.log.WithField(logFieldCode, code).Debug("received PooledTransactions")
 
 	txs, err := c.receivePooledTransactions(ctx, data)
 	if err != nil {
@@ -42,6 +43,25 @@ func (c *Client) handlePooledTransactions(ctx context.Context, code uint64, data
 	channel, exists := c.pooledTransactionsMap[txs.ReqID()]
 	if exists && channel != nil {
 		channel <- txs
+	}
+
+	return nil
+}
+
+func (c *Client) sendPooledTransactions(ctx context.Context, txs *PooledTransactions) error {
+	c.log.WithFields(logrus.Fields{
+		logFieldCode:      PooledTransactionsCode,
+		logFieldRequestID: txs.RequestId,
+		"txs_count":       txs.List.Len(),
+	}).Debug("sending PooledTransactions")
+
+	encodedData, err := rlp.EncodeToBytes(txs)
+	if err != nil {
+		return fmt.Errorf("error encoding pooled transactions: %w", err)
+	}
+
+	if err := c.writeRLPx(PooledTransactionsCode, encodedData); err != nil {
+		return fmt.Errorf("error sending pooled transactions: %w", err)
 	}
 
 	return nil

--- a/pkg/execution/mimicry/message_receipts.go
+++ b/pkg/execution/mimicry/message_receipts.go
@@ -28,6 +28,20 @@ func (msg *Receipts69) Code() int { return ReceiptsCode }
 
 func (msg *Receipts69) ReqID() uint64 { return msg.RequestId }
 
+type Receipts70Packet struct {
+	RequestId           uint64
+	LastBlockIncomplete bool
+	List                rlp.RawList[*eth.ReceiptList]
+}
+
+type Receipts70 struct {
+	Receipts70Packet
+}
+
+func (msg *Receipts70) Code() int { return ReceiptsCode }
+
+func (msg *Receipts70) ReqID() uint64 { return msg.RequestId }
+
 func (c *Client) sendReceipts(ctx context.Context, r Receipts) error {
 	var requestID uint64
 
@@ -42,22 +56,26 @@ func (c *Client) sendReceipts(ctx context.Context, r Receipts) error {
 		requestID = receipts.RequestId
 		listCount = receipts.List.Len()
 		encodedData, err = rlp.EncodeToBytes(&receipts.ReceiptsPacket)
+	case *Receipts70:
+		requestID = receipts.RequestId
+		listCount = receipts.List.Len()
+		encodedData, err = rlp.EncodeToBytes(&receipts.Receipts70Packet)
 	default:
 		return fmt.Errorf("unsupported receipts type: %T", r)
 	}
 
 	c.log.WithFields(logrus.Fields{
-		"code":           ReceiptsCode,
-		"request_id":     requestID,
-		"receipts_count": listCount,
-		"ethCapVersion":  c.ethCapVersion,
+		logFieldCode:      ReceiptsCode,
+		logFieldRequestID: requestID,
+		"receipts_count":  listCount,
+		logFieldETHCap:    c.ethCapVersion,
 	}).Debug("sending Receipts")
 
 	if err != nil {
 		return fmt.Errorf("error encoding block receipts: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(ReceiptsCode, encodedData); err != nil {
+	if err := c.writeRLPx(ReceiptsCode, encodedData); err != nil {
 		return fmt.Errorf("error sending block receipts: %w", err)
 	}
 

--- a/pkg/execution/mimicry/message_receipts_test.go
+++ b/pkg/execution/mimicry/message_receipts_test.go
@@ -1,10 +1,14 @@
 package mimicry
 
 import (
+	"context"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReceipts69Code(t *testing.T) {
@@ -22,8 +26,19 @@ func TestReceipts69ReqID(t *testing.T) {
 	assert.Equal(t, uint64(66666), msg.ReqID())
 }
 
+func TestReceipts70ReqID(t *testing.T) {
+	msg := &Receipts70{
+		Receipts70Packet: Receipts70Packet{
+			RequestId:           66666,
+			LastBlockIncomplete: false,
+		},
+	}
+	assert.Equal(t, uint64(66666), msg.ReqID())
+}
+
 func TestReceiptsInterfaceCompliance(t *testing.T) {
 	var _ Receipts = (*Receipts69)(nil)
+	var _ Receipts = (*Receipts70)(nil)
 }
 
 func TestGetReceiptsCode(t *testing.T) {
@@ -37,6 +52,27 @@ func TestGetReceiptsReqID(t *testing.T) {
 		RequestId: 77777,
 	}
 	assert.Equal(t, uint64(77777), msg.ReqID())
+}
+
+func TestReceiveGetReceipts70(t *testing.T) {
+	hash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	packet := GetReceipts70Packet{
+		RequestId:              77777,
+		FirstBlockReceiptIndex: 5,
+		GetReceiptsRequest:     eth.GetReceiptsRequest{hash},
+	}
+	encoded, err := rlp.EncodeToBytes(&packet)
+	require.NoError(t, err)
+
+	client := &Client{ethCapVersion: 70}
+	msg, err := client.receiveGetReceipts(context.Background(), encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(77777), msg.ReqID())
+	assert.Equal(t, ReceiptRequest{
+		Hashes:                 []common.Hash{hash},
+		FirstBlockReceiptIndex: 5,
+	}, msg.ReceiptRequest())
 }
 
 func TestReceiptsCodeConstant(t *testing.T) {

--- a/pkg/execution/mimicry/message_status.go
+++ b/pkg/execution/mimicry/message_status.go
@@ -4,7 +4,10 @@ package mimicry
 import (
 	"context"
 	"fmt"
+	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/sirupsen/logrus"
@@ -18,6 +21,7 @@ const (
 type Status interface {
 	Code() int
 	ReqID() uint64
+	GetProtocolVersion() uint32
 	GetGenesis() []byte
 	GetHead() []byte
 	GetNetworkID() uint64
@@ -25,13 +29,44 @@ type Status interface {
 	GetForkIDNext() uint64
 }
 
+type Status68Packet struct {
+	ProtocolVersion uint32
+	NetworkID       uint64
+	TD              *big.Int
+	Head            common.Hash
+	Genesis         common.Hash
+	ForkID          forkid.ID
+}
+
+type Status68 struct {
+	Status68Packet
+}
+
 type Status69 struct {
 	eth.StatusPacket
 }
 
+func (msg *Status68) Code() int { return StatusCode }
+
+func (msg *Status68) ReqID() uint64 { return 0 }
+
+func (msg *Status68) GetProtocolVersion() uint32 { return msg.ProtocolVersion }
+
+func (msg *Status68) GetGenesis() []byte { return msg.Genesis[:] }
+
+func (msg *Status68) GetHead() []byte { return msg.Head[:] }
+
+func (msg *Status68) GetNetworkID() uint64 { return msg.NetworkID }
+
+func (msg *Status68) GetForkIDHash() []byte { return msg.ForkID.Hash[:] }
+
+func (msg *Status68) GetForkIDNext() uint64 { return msg.ForkID.Next }
+
 func (msg *Status69) Code() int { return StatusCode }
 
 func (msg *Status69) ReqID() uint64 { return 0 }
+
+func (msg *Status69) GetProtocolVersion() uint32 { return msg.ProtocolVersion }
 
 func (msg *Status69) GetGenesis() []byte { return msg.Genesis[:] }
 
@@ -44,19 +79,31 @@ func (msg *Status69) GetForkIDHash() []byte { return msg.ForkID.Hash[:] }
 func (msg *Status69) GetForkIDNext() uint64 { return msg.ForkID.Next }
 
 func (c *Client) receiveStatus(ctx context.Context, data []byte) (Status, error) {
-	s := new(Status69)
-	if err := rlp.DecodeBytes(data, &s.StatusPacket); err != nil {
-		return nil, fmt.Errorf("error decoding status: %w", err)
-	}
+	switch c.ethCapVersion {
+	case 68:
+		s := new(Status68)
+		if err := rlp.DecodeBytes(data, &s.Status68Packet); err != nil {
+			return nil, fmt.Errorf("error decoding eth/68 status: %w", err)
+		}
 
-	return s, nil
+		return s, nil
+	case 69, 70:
+		s := new(Status69)
+		if err := rlp.DecodeBytes(data, &s.StatusPacket); err != nil {
+			return nil, fmt.Errorf("error decoding eth/%d status: %w", c.ethCapVersion, err)
+		}
+
+		return s, nil
+	default:
+		return nil, fmt.Errorf("unsupported eth protocol version for status: %d", c.ethCapVersion)
+	}
 }
 
 func (c *Client) sendStatus(ctx context.Context, status Status) error {
 	c.log.WithFields(logrus.Fields{
-		"code":          StatusCode,
-		"status":        status,
-		"ethCapVersion": c.ethCapVersion,
+		logFieldCode:   StatusCode,
+		"status":       status,
+		logFieldETHCap: c.ethCapVersion,
 	}).Debug("sending Status")
 
 	var encodedData []byte
@@ -64,6 +111,8 @@ func (c *Client) sendStatus(ctx context.Context, status Status) error {
 	var err error
 
 	switch s := status.(type) {
+	case *Status68:
+		encodedData, err = rlp.EncodeToBytes(&s.Status68Packet)
 	case *Status69:
 		encodedData, err = rlp.EncodeToBytes(&s.StatusPacket)
 	default:
@@ -74,17 +123,19 @@ func (c *Client) sendStatus(ctx context.Context, status Status) error {
 		return fmt.Errorf("error encoding status: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(StatusCode, encodedData); err != nil {
+	if err := c.writeRLPx(StatusCode, encodedData); err != nil {
 		return fmt.Errorf("error sending status: %w", err)
 	}
+
+	c.statusSent = true
 
 	return nil
 }
 
 func (c *Client) handleStatus(ctx context.Context, code uint64, data []byte) error {
 	c.log.WithFields(logrus.Fields{
-		"code":          code,
-		"ethCapVersion": c.ethCapVersion,
+		logFieldCode:   code,
+		logFieldETHCap: c.ethCapVersion,
 	}).Debug("received Status")
 
 	status, err := c.receiveStatus(ctx, data)
@@ -92,10 +143,24 @@ func (c *Client) handleStatus(ctx context.Context, code uint64, data []byte) err
 		return err
 	}
 
+	response := status
+	if c.statusProvider != nil {
+		provided, perr := c.statusProvider(ctx, c.ethCapVersion, status)
+		if perr != nil {
+			return fmt.Errorf("failed to build provided Status: %w", perr)
+		}
+
+		if provided != nil {
+			response = provided
+		}
+	}
+
 	c.publishStatus(ctx, status)
 
-	if err := c.sendStatus(ctx, status); err != nil {
-		return err
+	if !c.statusSent {
+		if err := c.sendStatus(ctx, response); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/execution/mimicry/message_status_test.go
+++ b/pkg/execution/mimicry/message_status_test.go
@@ -1,12 +1,16 @@
 package mimicry
 
 import (
+	"context"
+	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,10 +18,43 @@ import (
 func TestStatusCode(t *testing.T) {
 	expectedCode := RLPXOffset + eth.StatusMsg
 
+	status68 := &Status68{}
 	status69 := &Status69{}
+	assert.Equal(t, expectedCode, status68.Code())
 	assert.Equal(t, expectedCode, status69.Code())
 
 	assert.Equal(t, StatusCode, expectedCode)
+}
+
+func TestStatus68Interface(t *testing.T) {
+	genesis := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+	head := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
+
+	status := &Status68{
+		Status68Packet: Status68Packet{
+			ProtocolVersion: 68,
+			NetworkID:       1,
+			TD:              big.NewInt(0),
+			Head:            head,
+			Genesis:         genesis,
+			ForkID: forkid.ID{
+				Hash: forkIDHash,
+				Next: 2000,
+			},
+		},
+	}
+
+	var _ Status = status
+
+	assert.Equal(t, StatusCode, status.Code())
+	assert.Equal(t, uint64(0), status.ReqID())
+	assert.Equal(t, uint32(68), status.GetProtocolVersion())
+	assert.Equal(t, genesis[:], status.GetGenesis())
+	assert.Equal(t, head[:], status.GetHead())
+	assert.Equal(t, uint64(1), status.GetNetworkID())
+	assert.Equal(t, forkIDHash[:], status.GetForkIDHash())
+	assert.Equal(t, uint64(2000), status.GetForkIDNext())
 }
 
 func TestStatus69Interface(t *testing.T) {
@@ -44,11 +81,46 @@ func TestStatus69Interface(t *testing.T) {
 
 	assert.Equal(t, StatusCode, status.Code())
 	assert.Equal(t, uint64(0), status.ReqID())
+	assert.Equal(t, uint32(69), status.GetProtocolVersion())
 	assert.Equal(t, genesis[:], status.GetGenesis())
 	assert.Equal(t, latestBlockHash[:], status.GetHead())
 	assert.Equal(t, uint64(1), status.GetNetworkID())
 	assert.Equal(t, forkIDHash[:], status.GetForkIDHash())
 	assert.Equal(t, uint64(2000), status.GetForkIDNext())
+}
+
+func TestStatusRLPEncoding68(t *testing.T) {
+	genesis := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+	head := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
+
+	original := Status68Packet{
+		ProtocolVersion: 68,
+		NetworkID:       1,
+		TD:              big.NewInt(0),
+		Head:            head,
+		Genesis:         genesis,
+		ForkID: forkid.ID{
+			Hash: forkIDHash,
+			Next: 2000,
+		},
+	}
+
+	encoded, err := rlp.EncodeToBytes(&original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	var decoded Status68Packet
+	err = rlp.DecodeBytes(encoded, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.ProtocolVersion, decoded.ProtocolVersion)
+	assert.Equal(t, original.NetworkID, decoded.NetworkID)
+	assert.Equal(t, original.TD, decoded.TD)
+	assert.Equal(t, original.Head, decoded.Head)
+	assert.Equal(t, original.Genesis, decoded.Genesis)
+	assert.Equal(t, original.ForkID.Hash, decoded.ForkID.Hash)
+	assert.Equal(t, original.ForkID.Next, decoded.ForkID.Next)
 }
 
 func TestStatusRLPEncoding69(t *testing.T) {
@@ -87,7 +159,40 @@ func TestStatusRLPEncoding69(t *testing.T) {
 	assert.Equal(t, original.LatestBlockHash, decoded.LatestBlockHash)
 }
 
+func TestReceiveStatus70UsesRangeStatusPacket(t *testing.T) {
+	genesis := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+	latestBlockHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	forkIDHash := [4]byte{0xfc, 0x64, 0xec, 0x04}
+
+	original := eth.StatusPacket{
+		ProtocolVersion: 70,
+		NetworkID:       1,
+		Genesis:         genesis,
+		ForkID: forkid.ID{
+			Hash: forkIDHash,
+			Next: 2000,
+		},
+		EarliestBlock:   100,
+		LatestBlock:     500,
+		LatestBlockHash: latestBlockHash,
+	}
+
+	encoded, err := rlp.EncodeToBytes(&original)
+	require.NoError(t, err)
+
+	client := &Client{ethCapVersion: 70}
+	status, err := client.receiveStatus(context.Background(), encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(70), status.GetProtocolVersion())
+	assert.Equal(t, genesis[:], status.GetGenesis())
+	assert.Equal(t, latestBlockHash[:], status.GetHead())
+	assert.Equal(t, forkIDHash[:], status.GetForkIDHash())
+	assert.Equal(t, uint64(2000), status.GetForkIDNext())
+}
+
 func TestStatusInterfaceCompliance(t *testing.T) {
+	var _ Status = (*Status68)(nil)
 	var _ Status = (*Status69)(nil)
 }
 
@@ -112,4 +217,27 @@ func TestStatusDifferentNetworks(t *testing.T) {
 			assert.Equal(t, tt.networkID, status69.GetNetworkID())
 		})
 	}
+}
+
+func TestHandleStatusReturnsStatusProviderError(t *testing.T) {
+	status := &Status69{
+		StatusPacket: eth.StatusPacket{
+			ProtocolVersion: 69,
+			NetworkID:       56,
+		},
+	}
+	encoded, err := rlp.EncodeToBytes(&status.StatusPacket)
+	require.NoError(t, err)
+
+	expected := errors.New("wrong network")
+	client := &Client{
+		ethCapVersion: 69,
+		log:           logrus.New(),
+		statusProvider: func(ctx context.Context, protocolVersion uint, peerStatus Status) (Status, error) {
+			return nil, expected
+		},
+	}
+
+	err = client.handleStatus(context.Background(), StatusCode, encoded)
+	require.ErrorIs(t, err, expected)
 }

--- a/pkg/execution/mimicry/message_transactions.go
+++ b/pkg/execution/mimicry/message_transactions.go
@@ -30,7 +30,7 @@ func (c *Client) receiveTransactions(ctx context.Context, data []byte) (*Transac
 }
 
 func (c *Client) handleTransactions(ctx context.Context, code uint64, data []byte) error {
-	c.log.WithField("code", code).Debug("received Transactions")
+	c.log.WithField(logFieldCode, code).Debug("received Transactions")
 
 	txs, err := c.receiveTransactions(ctx, data)
 	if err != nil {
@@ -44,7 +44,7 @@ func (c *Client) handleTransactions(ctx context.Context, code uint64, data []byt
 
 func (c *Client) sendTransactions(ctx context.Context, transactions *Transactions) error {
 	c.log.WithFields(logrus.Fields{
-		"code":         TransactionsCode,
+		logFieldCode:   TransactionsCode,
 		"transactions": transactions,
 	}).Debug("sending Transactions")
 
@@ -53,7 +53,7 @@ func (c *Client) sendTransactions(ctx context.Context, transactions *Transaction
 		return fmt.Errorf("error encoding transactions: %w", err)
 	}
 
-	if _, err := c.rlpxConn.Write(TransactionsCode, encodedData); err != nil {
+	if err := c.writeRLPx(TransactionsCode, encodedData); err != nil {
 		return fmt.Errorf("error sending transactions: %w", err)
 	}
 

--- a/pkg/execution/mimicry/options.go
+++ b/pkg/execution/mimicry/options.go
@@ -1,0 +1,55 @@
+package mimicry
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+)
+
+type StatusProvider func(ctx context.Context, protocolVersion uint, peerStatus Status) (Status, error)
+
+type HeaderProvider func(ctx context.Context, request *eth.GetBlockHeadersRequest) ([]*types.Header, error)
+
+type BodyProvider func(ctx context.Context, hashes []common.Hash) ([]eth.BlockBody, error)
+
+type ReceiptRequest struct {
+	Hashes                 []common.Hash
+	FirstBlockReceiptIndex uint64
+}
+
+type ReceiptProvider func(ctx context.Context, request ReceiptRequest) ([]*eth.ReceiptList, error)
+
+type Option func(*Client)
+
+func WithStatusProvider(provider StatusProvider) Option {
+	return func(c *Client) {
+		c.statusProvider = provider
+	}
+}
+
+func WithHeaderProvider(provider HeaderProvider) Option {
+	return func(c *Client) {
+		c.headerProvider = provider
+	}
+}
+
+func WithBodyProvider(provider BodyProvider) Option {
+	return func(c *Client) {
+		c.bodyProvider = provider
+	}
+}
+
+func WithReceiptProvider(provider ReceiptProvider) Option {
+	return func(c *Client) {
+		c.receiptProvider = provider
+	}
+}
+
+func WithPrivateKey(privateKey *ecdsa.PrivateKey) Option {
+	return func(c *Client) {
+		c.privateKey = privateKey
+	}
+}

--- a/pkg/testutil/kurtosis/network.go
+++ b/pkg/testutil/kurtosis/network.go
@@ -37,6 +37,8 @@ var defaultManager = &networkManager{
 	instances: make(map[string]*managedNetwork),
 }
 
+const ethereumPackageVersion = "6.0.0"
+
 // GetNetwork retrieves or creates a Kurtosis network based on the provided configuration.
 // It reuses existing networks when possible to improve test performance.
 // Note: This returns a TestFoundation, not just an EnclaveContext, because ethereum-package-go
@@ -114,7 +116,9 @@ func setupKurtosisNetwork(ctx context.Context, config *NetworkConfig) (*TestFoun
 	time.Sleep(500 * time.Millisecond)
 
 	// Configure network options
-	var opts []ethereum.RunOption
+	opts := []ethereum.RunOption{
+		ethereum.WithPackageVersion(ethereumPackageVersion),
+	}
 
 	// Handle KeepAlive configuration
 	if config.KeepAlive {


### PR DESCRIPTION
Updates execution mimicry with current ETH protocol support for eth/68, eth/69, and eth/70 peers.

The package now supports provided Status responses, stable local devp2p identities, serialized RLPx writes, eth/70 receipt messages, pooled transaction requests, and more tolerant disconnect decoding.

This also adds focused coverage for the protocol edge cases used by xatu mimicry when staying peered with mainnet execution clients.
